### PR TITLE
General issue fixes

### DIFF
--- a/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
@@ -32,6 +32,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
@@ -366,9 +367,11 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
                     // with the key and the link to the QR image.
                     // otherwise, we would want to completely void the player's key data, remove the QRItem and also send him a message about the issue.
                     if (getPendingKey(player.getUniqueId()) != null) {
-                        sendClickableMessage(player,
-                                ColorUtils.translateAlternateColorCodes('&', MessageHandler.TwoFAMessages.PREFIX.getMessage() + MessageHandler.TwoFAMessages.CLICK_TO_OPEN_QR.getMessage()),
-                                url.replaceAll("128x128", "256x256"));
+                        if (!Objects.equals(MessageHandler.TwoFAMessages.CLICK_TO_OPEN_QR.getMessage(), "")) {
+                            sendClickableMessage(player,
+                                    ColorUtils.translateAlternateColorCodes('&', MessageHandler.TwoFAMessages.PREFIX.getMessage() + MessageHandler.TwoFAMessages.CLICK_TO_OPEN_QR.getMessage()),
+                                    url.replaceAll("128x128", "256x256"));
+                        }
 
                         sendHoverMessage(player,
                                 ColorUtils.translateAlternateColorCodes('&', MessageHandler.TwoFAMessages.PREFIX.getMessage() + MessageHandler.TwoFAMessages.USE_QR_CODE_TO_SETUP_2FA.getMessage()),

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -12,6 +12,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -183,5 +184,13 @@ public class DisabledEvents implements Listener {
                 event.setCancelled(true);
             }
         }
+    }
+
+    @EventHandler (priority = EventPriority.HIGHEST)
+    public void onDeath(PlayerDeathEvent event) {
+        if(!this.main.getAuthHandler().needsToAuthenticate(event.getEntity().getUniqueId())) return;
+
+        // Don't drop items if the player needs to authenticate.
+        event.getDrops().clear();
     }
 }

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -188,6 +188,8 @@ public class DisabledEvents implements Listener {
 
     @EventHandler (priority = EventPriority.HIGHEST)
     public void onDeath(PlayerDeathEvent event) {
+        if(!this.main.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)) return;
+
         if(!this.main.getAuthHandler().needsToAuthenticate(event.getEntity().getUniqueId())) return;
 
         // Don't drop items if the player needs to authenticate.

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -17,6 +17,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
+import org.bukkit.inventory.ItemStack;
 
 public class DisabledEvents implements Listener {
 
@@ -192,7 +193,7 @@ public class DisabledEvents implements Listener {
 
         if(!this.main.getAuthHandler().needsToAuthenticate(event.getEntity().getUniqueId())) return;
 
-        // Don't drop items if the player needs to authenticate.
-        event.getDrops().clear();
+        // Don't drop the QR Code item if the player needs to authenticate.
+        event.getDrops().removeIf(item -> this.main.getAuthHandler().isQRCodeItem(item));
     }
 }

--- a/src/main/java/com/lielamar/auth/shared/handlers/ConfigHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/handlers/ConfigHandler.java
@@ -7,6 +7,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.player.*;
@@ -140,7 +141,8 @@ public abstract class ConfigHandler {
         CHANGE_SLOT(PlayerItemHeldEvent.class),
         COMMANDS(PlayerCommandPreprocessEvent.class),
         MOVE_ITEM(InventoryMoveItemEvent.class),
-        INTERACT_WITH_FRAMES(PlayerInteractEntityEvent.class);
+        INTERACT_WITH_FRAMES(PlayerInteractEntityEvent.class),
+        DEATH(PlayerDeathEvent.class);
 
         private final Class<? extends Event> matchingEvent;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -56,6 +56,7 @@ disabled-events:
   commands: true
   move-item: true
   interact-with-frames: true
+  death: true
 
 # If the "commands" event is disabled, you can whitelist specific commands with the below setting
 # These commands only will executed successfully. Anything else will be blocked.


### PR DESCRIPTION
As suggested by #75. By default when the player dies the event drops is cleared. This can be disabled in the configuration file.