### PR TITLE
Removing unnecessary event

### DIFF
--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -91,7 +91,7 @@ public class DisabledEvents implements Listener {
             event.getItem().remove();
         }
     }
-
+    
     @EventHandler (priority = EventPriority.HIGHEST)
     public void onEntityDamage(EntityDamageEvent event) {
         if(!this.plugin.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)) return;

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -93,19 +93,6 @@ public class DisabledEvents implements Listener {
     }
 
     @EventHandler (priority = EventPriority.HIGHEST)
-    public void onItemPickup(EntityPickupItemEvent event) {
-        if(!(event.getEntity() instanceof Player)) return;
-        
-        if(!this.plugin.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)) return;
-
-        if(this.plugin.getAuthHandler().needsToAuthenticate(event.getEntity().getUniqueId())) {
-            event.setCancelled(true);
-        } else if(this.plugin.getAuthHandler().isQRCodeItem(event.getItem().getItemStack())) {
-            event.getItem().remove();
-        }
-    }
-
-    @EventHandler (priority = EventPriority.HIGHEST)
     public void onEntityDamage(EntityDamageEvent event) {
         if(!this.plugin.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)) return;
 

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -12,7 +12,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;


### PR DESCRIPTION
If the plugin is executed with version 1.8 it does not register events and jumps.

`[20:28:49] [Server thread/ERROR]: [2FA] Plugin 2FA v1.6.1 has failed to register events for class com.lielamar.auth.bukkit.listeners.DisabledEvents because org/bukkit/event/entity/EntityPickupItemEvent does not exist.`

This PR fixes that error.