### PR TITLE
add option to disable movement changes

### DIFF
--- a/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
@@ -38,7 +38,7 @@ public class OnAuthStateChange implements Listener {
     public void onStateChange(PlayerStateChangeEvent event) {
         if (event.getNewAuthState().equals(AuthHandler.AuthState.AUTHENTICATED)) {
             
-            if (plugin.getConfig().getBoolean("change-walking-speed", false){
+            if (plugin.getConfig().getBoolean("change-walking-speed", false)) {
                 event.getPlayer().setFlySpeed((float) 0.1);
                 event.getPlayer().setWalkSpeed((float) 0.2);
             }

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
@@ -37,8 +37,11 @@ public class OnAuthStateChange implements Listener {
     @EventHandler
     public void onStateChange(PlayerStateChangeEvent event) {
         if (event.getNewAuthState().equals(AuthHandler.AuthState.AUTHENTICATED)) {
-            event.getPlayer().setFlySpeed((float) 0.1);
-            event.getPlayer().setWalkSpeed((float) 0.2);
+            
+            if (plugin.getConfig().getBoolean("change-walking-speed", false){
+                event.getPlayer().setFlySpeed((float) 0.1);
+                event.getPlayer().setWalkSpeed((float) 0.2);
+            }
 
             this.plugin.getStorageHandler().setIP(event.getPlayer().getUniqueId(),
                     this.hash.hash(event.getPlayer().getAddress().getAddress().getHostAddress()));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,6 +33,9 @@ map-ids: []
 # - NONE (no hash - not recommended!)
 ip-hash: SHA256
 
+# The player walk speed changes on joining
+change-walking-speed: true
+
 # How much delay should the plugin apply to loading players when the server reloads
 # This is useful when you have multiple databases with different latencies
 # You can use it to ensure your permissions plugin loads before the players are reloaded


### PR DESCRIPTION
The movement effects bedrock players in a way where they cant properly move afterwards, would be nice to have disable-able 