### PR TITLE
QR Code Integration and Bug Fixes, Deps Updates and Refinements for 1.7 2FA

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,4 +1,4 @@
-name: "Install, Build & Test"
+name: Install, Build & Test
 
 on:
   pull_request:
@@ -10,21 +10,21 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: '8'
-        distribution: 'adopt'
-        server-id: github
-        settings-path: ${{ github.workspace }}
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17 (Amazon Corretto)
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          server-id: github
+          settings-path: ${{ github.workspace }}
 
-    - name: Build with Gradle
-      run: gradle :clean :build
+      - name: Build with Gradle
+        run: gradle :clean :build
+

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'corretto'
+          distribution: 'adopt'
           server-id: github
           settings-path: ${{ github.workspace }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.lielamar.auth'
-version = '1.7'
+version = '1.7.0'
 
 defaultTasks 'clean', 'shadowJar'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,20 @@
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 group = 'com.lielamar.auth'
-version = '1.6.4'
+version = '1.7'
 
 defaultTasks 'clean', 'shadowJar'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
 
-    maven {
-        url = 'https://api.lielamar.com/repository/maven-public/'
-        content {
-            content {
-                includeGroup "net.byteflux"
-                includeGroup "com.lielamar"
-                includeGroup "com.lielamar.ConnectionsManager"
-            }
-        }
-    }
-
+    maven { url = "https://repo.alessiodp.com/releases/" }
+    maven { url = "https://repo.papermc.io/repository/maven-public/" }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url = 'https://repo.velocitypowered.com/snapshots/' }
@@ -32,30 +23,27 @@ repositories {
 }
 
 dependencies {
-    
-    implementation 'org.json:json:20220320'
-    
-    implementation 'com.lielamar:LielsUtils:1.6.31'
+    implementation 'org.json:json:20240303'
 
-    implementation 'net.byteflux:libby-core:1.1.5-v2'
-    implementation 'net.byteflux:libby-bukkit:1.1.5'
+    implementation 'net.byteflux:libby-core:1.3.0'
+    implementation 'net.byteflux:libby-bukkit:1.3.0'
 
-    compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
-    compileOnly 'net.md-5:bungeecord-api:1.19-R0.1-SNAPSHOT'
-    compileOnly 'com.velocitypowered:velocity-api:3.1.0'
+    compileOnly 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-api:1.21-R0.1-SNAPSHOT'
+    compileOnly 'com.velocitypowered:velocity-api:3.3.0-SNAPSHOT'
 
-    compileOnly 'me.clip:placeholderapi:2.11.2'
+    compileOnly 'me.clip:placeholderapi:2.11.6'
 
-    compileOnly 'org.apache.logging.log4j:log4j-core:2.18.0'
-    compileOnly 'com.warrenstrange:googleauth:1.5.0'
-    compileOnly 'commons-codec:commons-codec:1.15'
-    compileOnly 'com.zaxxer:HikariCP:4.0.3'
-    compileOnly 'com.h2database:h2:2.1.214'
-    compileOnly 'mysql:mysql-connector-java:8.0.29'
-    compileOnly 'org.postgresql:postgresql:42.5.0'
-    compileOnly 'org.mariadb.jdbc:mariadb-java-client:3.0.7'
-    compileOnly 'org.mongodb:mongo-java-driver:3.12.11'
-    compileOnly 'org.slf4j:slf4j-api:2.0.0'
+    compileOnly 'org.apache.logging.log4j:log4j-core:2.23.1'
+    compileOnly 'com.atlassian:onetime:2.1.1'
+    compileOnly 'commons-codec:commons-codec:1.17.0'
+    compileOnly 'com.zaxxer:HikariCP:5.1.0'
+    compileOnly 'com.h2database:h2:2.2.224'
+    compileOnly 'com.mysql:mysql-connector-j:8.4.0'
+    compileOnly 'org.postgresql:postgresql:42.7.3'
+    compileOnly 'org.mariadb.jdbc:mariadb-java-client:3.4.0'
+    compileOnly 'org.mongodb:mongodb-driver-sync:5.1.1'
+    compileOnly 'org.slf4j:slf4j-api:2.0.13'
 }
 
 jar {
@@ -64,8 +52,6 @@ jar {
 }
 
 shadowJar {
-    classifier = null
-
     relocate 'net.byteflux', 'com.lielamar.auth.shade'
     relocate 'org.json', 'com.lielamar.auth.shade.json'
     relocate 'com.google.gson', 'com.lielamar.auth.shade.gson'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,6 @@ shadowJar {
     relocate 'com.google.gson', 'com.lielamar.auth.shade.gson'
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthentication.java
+++ b/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthentication.java
@@ -3,31 +3,28 @@ package com.lielamar.auth.bukkit;
 import com.lielamar.auth.bukkit.commands.TwoFactorAuthenticationCommand;
 import com.lielamar.auth.bukkit.communication.BasicAuthCommunication;
 import com.lielamar.auth.bukkit.communication.ProxyAuthCommunication;
-import com.lielamar.auth.bukkit.listeners.OnMapDrop;
-import com.lielamar.auth.shared.TwoFactorAuthenticationPlugin;
-import com.lielamar.auth.shared.communication.AuthCommunicationHandler;
-import com.lielamar.auth.shared.communication.CommunicationMethod;
-import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.updater.SpigotUpdateChecker;
-import com.lielamar.lielsutils.bukkit.bstats.BukkitMetrics;
-import com.lielamar.lielsutils.bukkit.files.FileManager;
-
 import com.lielamar.auth.bukkit.handlers.*;
 import com.lielamar.auth.bukkit.listeners.DisabledEvents;
 import com.lielamar.auth.bukkit.listeners.OnAuthStateChange;
+import com.lielamar.auth.bukkit.listeners.OnMapDrop;
 import com.lielamar.auth.bukkit.listeners.OnPlayerConnection;
+import com.lielamar.auth.bukkit.utils.bstats.BukkitMetrics;
+import com.lielamar.auth.bukkit.utils.file.FileManager;
+import com.lielamar.auth.bukkit.utils.update.SpigotUpdateChecker;
+import com.lielamar.auth.shared.TwoFactorAuthenticationPlugin;
+import com.lielamar.auth.shared.communication.AuthCommunicationHandler;
+import com.lielamar.auth.shared.communication.CommunicationMethod;
 import com.lielamar.auth.shared.storage.StorageHandler;
 import com.lielamar.auth.shared.utils.AuthTracker;
-
+import com.lielamar.auth.shared.utils.Constants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
-
-import org.apache.logging.log4j.core.Logger;
 
 import java.util.Iterator;
 

--- a/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthentication.java
+++ b/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthentication.java
@@ -78,7 +78,7 @@ public class TwoFactorAuthentication extends JavaPlugin implements TwoFactorAuth
 
     private void setupDependencies() {
         try {
-            Class.forName("com.warrenstrange.googleauth.GoogleAuthenticator");
+            Class.forName("com.atlassian.onetime.service.DefaultTOTPService");
         } catch (ClassNotFoundException exception) {
             Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.YELLOW + "[2FA] The default spigot dependency loader either does not exist or failed to load dependencies. Falling back to a custom dependency loader");
             new DependencyHandler(this);

--- a/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthenticationPlaceholders.java
+++ b/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthenticationPlaceholders.java
@@ -5,6 +5,7 @@ import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 public class TwoFactorAuthenticationPlaceholders extends PlaceholderExpansion {
 
@@ -15,17 +16,17 @@ public class TwoFactorAuthenticationPlaceholders extends PlaceholderExpansion {
     }
 
     @Override
-    public String getIdentifier() {
+    public @NotNull String getIdentifier() {
         return "2FA";
     }
 
     @Override
-    public String getAuthor() {
+    public @NotNull String getAuthor() {
         return plugin.getDescription().getAuthors().get(0);
     }
 
     @Override
-    public String getVersion() {
+    public @NotNull String getVersion() {
         return plugin.getDescription().getVersion();
     }
 

--- a/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthenticationPlaceholders.java
+++ b/src/main/java/com/lielamar/auth/bukkit/TwoFactorAuthenticationPlaceholders.java
@@ -1,9 +1,8 @@
 package com.lielamar.auth.bukkit;
 
-import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.time.TimeUtils;
-
+import com.lielamar.auth.bukkit.utils.TimeUtils;
 import com.lielamar.auth.shared.handlers.MessageHandler;
+import com.lielamar.auth.shared.utils.Constants;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
 
@@ -32,27 +31,22 @@ public class TwoFactorAuthenticationPlaceholders extends PlaceholderExpansion {
 
     @Override
     public String onPlaceholderRequest(Player player, String identifier) {
-        switch (identifier.toLowerCase()) {
-            case "is_enabled":
-                return plugin.getAuthHandler().is2FAEnabled(player.getUniqueId())
-                        ? MessageHandler.TwoFAMessages.KEYWORD_ENABLED.getMessage()
-                        : MessageHandler.TwoFAMessages.KEYWORD_DISABLED.getMessage();
-                
-            case "time_since_enabled":
+        return switch (identifier.toLowerCase()) {
+            case "is_enabled" -> plugin.getAuthHandler().is2FAEnabled(player.getUniqueId())
+                    ? MessageHandler.TwoFAMessages.KEYWORD_ENABLED.getMessage()
+                    : MessageHandler.TwoFAMessages.KEYWORD_DISABLED.getMessage();
+            case "time_since_enabled" -> {
                 long enableDate = plugin.getAuthHandler().getStorageHandler().getEnableDate(player.getUniqueId());
-                return enableDate == -1 ? "Not Enabled"
+                yield enableDate == -1 ? "Not Enabled"
                         : TimeUtils.parseTime(System.currentTimeMillis() - enableDate);
-                
-            case "key":
-                return plugin.getAuthHandler().getStorageHandler()
-                        .getKey(player.getUniqueId());
-                
-            case "is_required":
-                return player.hasPermission(Constants.demandPermission)
-                        ? MessageHandler.TwoFAMessages.KEYWORD_REQUIRED.getMessage()
-                        : MessageHandler.TwoFAMessages.KEYWORD_NOT_REQUIRED.getMessage();
-        }
+            }
+            case "key" -> plugin.getAuthHandler().getStorageHandler()
+                    .getKey(player.getUniqueId());
+            case "is_required" -> player.hasPermission(Constants.demandPermission)
+                    ? MessageHandler.TwoFAMessages.KEYWORD_REQUIRED.getMessage()
+                    : MessageHandler.TwoFAMessages.KEYWORD_NOT_REQUIRED.getMessage();
+            default -> null;
+        };
 
-        return null;
     }
 }

--- a/src/main/java/com/lielamar/auth/bukkit/commands/TwoFactorAuthenticationCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/TwoFactorAuthenticationCommand.java
@@ -2,11 +2,11 @@ package com.lielamar.auth.bukkit.commands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
 import com.lielamar.auth.bukkit.commands.subcommands.*;
+import com.lielamar.auth.bukkit.utils.cmd.Command;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.AuthHandler;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.Command;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/CancelCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/CancelCommand.java
@@ -1,10 +1,10 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/DisableCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/DisableCommand.java
@@ -1,11 +1,11 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
+import com.lielamar.auth.bukkit.utils.cmd.TabOptionsBuilder;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.bukkit.commands.TabOptionsBuilder;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/DisableForOthersCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/DisableForOthersCommand.java
@@ -1,14 +1,14 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
+import com.lielamar.auth.bukkit.utils.cmd.TabOptionsBuilder;
+import com.lielamar.auth.bukkit.utils.uuid.UUIDNotFoundException;
+import com.lielamar.auth.bukkit.utils.uuid.UUIDUtils;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.bukkit.commands.TabOptionsBuilder;
-import com.lielamar.lielsutils.exceptions.UUIDNotFoundException;
-import com.lielamar.lielsutils.groups.Pair;
-import com.lielamar.lielsutils.uuid.UUIDUtils;
+import com.lielamar.auth.shared.utils.groups.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/EnableCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/EnableCommand.java
@@ -1,12 +1,11 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
-import com.lielamar.auth.shared.handlers.AuthHandler;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
+import com.lielamar.auth.bukkit.utils.cmd.TabOptionsBuilder;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.bukkit.commands.TabOptionsBuilder;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/HelpCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/HelpCommand.java
@@ -1,11 +1,11 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.groups.Pair;
+import com.lielamar.auth.shared.utils.groups.Pair;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/LoginCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/LoginCommand.java
@@ -2,10 +2,10 @@ package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
 import com.lielamar.auth.bukkit.events.PlayerFailedAuthenticationEvent;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -42,7 +42,7 @@ public class LoginCommand extends StandaloneCommand {
         }
 
         try {
-            boolean isValid = this.plugin.getAuthHandler().validateKey(player.getUniqueId(), Integer.valueOf(code.toString()));
+            boolean isValid = this.plugin.getAuthHandler().validateKey(player.getUniqueId(), code.toString());
 
             if (isValid) {
                 this.plugin.getMessageHandler().sendMessage(player, MessageHandler.TwoFAMessages.SUCCESSFULLY_AUTHENTICATED);

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/ReloadCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/ReloadCommand.java
@@ -1,12 +1,12 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.file.FileManager;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.AuthHandler;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.bukkit.files.FileManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/ReportCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/ReportCommand.java
@@ -2,12 +2,10 @@ package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
 import com.lielamar.auth.bukkit.communication.ProxyAuthCommunication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.MessageHandler;
-import com.lielamar.auth.shared.storage.StorageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
-import com.lielamar.lielsutils.bukkit.version.Version;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -79,8 +77,7 @@ public class ReportCommand extends StandaloneCommand {
             writer.println("Server Jar, Versions and Information");
             writer.println("- Spigot Build version: " + Bukkit.getVersion());
             writer.println("- Server Version: " + Bukkit.getBukkitVersion());
-            writer.println("- Version Instance: " + Version.getInstance().getServerVersion().getVersionName());
-            writer.println("- NMSVersion Instance: " + Version.getInstance().getNMSVersion().getVersionName());
+            writer.println("- Version Instance: " + Bukkit.getServer().getBukkitVersion().split("-")[0].replaceAll("\\.", "_"));
             writer.println("- Max Memory: " + (Runtime.getRuntime().maxMemory() / 1000000) + " MB");
             writer.println("- Free Memory: " + (Runtime.getRuntime().freeMemory() / 1000000) + " MB");
             writer.println("- Total Memory: " + (Runtime.getRuntime().totalMemory() / 1000000) + " MB");

--- a/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/SetupCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/commands/subcommands/SetupCommand.java
@@ -1,10 +1,10 @@
 package com.lielamar.auth.bukkit.commands.subcommands;
 
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
+import com.lielamar.auth.bukkit.utils.cmd.StandaloneCommand;
+import com.lielamar.auth.bukkit.utils.cmd.SuperCommand;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.bukkit.commands.StandaloneCommand;
-import com.lielamar.lielsutils.bukkit.commands.SuperCommand;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -50,7 +50,7 @@ public class SetupCommand extends StandaloneCommand {
         }
 
         try {
-            boolean approved = this.plugin.getAuthHandler().approveKey(player.getUniqueId(), Integer.parseInt(code.toString()));
+            boolean approved = this.plugin.getAuthHandler().approveKey(player.getUniqueId(), code.toString());
 
             if (approved) {
                 this.plugin.getMessageHandler().sendMessage(player, MessageHandler.TwoFAMessages.SUCCESSFULLY_SETUP);

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
@@ -33,6 +33,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -174,7 +176,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
         super.authCommunicationHandler.loadPlayerState(uuid, new LoadAuthCallback(uuid));
     }
 
-    public @Nullable String getQRCodeURL(@NotNull UUID uuid) {
+    public @Nullable URI getQRCodeURL(@NotNull UUID uuid) {
         Player player = Bukkit.getPlayer(uuid);
 
         String label = (player == null) ? "player" : player.getName();
@@ -185,7 +187,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
             return null;
         }
 
-        return totpService.generateTOTPUrl(TOTPSecret.Companion.fromBase32EncodedString(key), new EmailAddress(label), new Issuer(title)).toString();
+        return totpService.generateTOTPUrl(TOTPSecret.Companion.fromBase32EncodedString(key), new EmailAddress(label), new Issuer(title));
     }
 
     /**
@@ -195,7 +197,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
      */
     @SuppressWarnings("deprecation")
     public void giveQRCodeItem(@NotNull Player player) {
-        String url = this.getQRCodeURL(player.getUniqueId());
+        String url = this.getQRCodeURL(player.getUniqueId()).toString();
 
         if (url == null) {
             return;
@@ -276,7 +278,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
                         resetKey(player.getUniqueId());
                         plugin.getMessageHandler().sendMessage(player, MessageHandler.TwoFAMessages.NULL_KEY);
                     }
-                } catch (IOException | NumberFormatException exception) {
+                } catch (NumberFormatException exception) {
                     exception.printStackTrace();
                     player.sendMessage(ChatColor.RED + "An error occurred! Is the URL correct?");
                 }

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/AuthHandler.java
@@ -3,6 +3,10 @@ package com.lielamar.auth.bukkit.handlers;
 import com.lielamar.auth.bukkit.TwoFactorAuthentication;
 import com.lielamar.auth.bukkit.communication.BasicAuthCommunication;
 import com.lielamar.auth.bukkit.events.PlayerStateChangeEvent;
+import com.lielamar.auth.shared.utils.color.ColorUtils;
+import com.lielamar.auth.bukkit.utils.map.ImageRender;
+import com.lielamar.auth.bukkit.utils.map.MapUtils;
+import com.lielamar.auth.bukkit.utils.version.Version;
 import com.lielamar.auth.shared.communication.AuthCommunicationHandler;
 import com.lielamar.auth.shared.handlers.MessageHandler;
 import com.lielamar.auth.shared.storage.StorageHandler;
@@ -11,12 +15,6 @@ import com.lielamar.auth.shared.utils.hash.Hash;
 import com.lielamar.auth.shared.utils.hash.NoHash;
 import com.lielamar.auth.shared.utils.hash.SHA256;
 import com.lielamar.auth.shared.utils.hash.SHA512;
-import com.lielamar.lielsutils.bukkit.color.ColorUtils;
-
-import com.lielamar.lielsutils.bukkit.map.ImageRender;
-import com.lielamar.lielsutils.bukkit.map.MapUtils;
-
-import com.lielamar.lielsutils.bukkit.version.Version;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -99,7 +97,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
     }
 
     @Override
-    public boolean validateKey(@NotNull UUID uuid, @NotNull Integer code) {
+    public boolean validateKey(@NotNull UUID uuid, @NotNull String code) {
         boolean valid = super.validateKey(uuid, code);
 
         Player player = Bukkit.getPlayer(uuid);
@@ -113,7 +111,7 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
     }
 
     @Override
-    public boolean approveKey(@NotNull UUID uuid, @NotNull Integer code) {
+    public boolean approveKey(@NotNull UUID uuid, @NotNull String code) {
         boolean approved = super.approveKey(uuid, code);
 
         if (approved) {
@@ -227,7 +225,6 @@ public class AuthHandler extends com.lielamar.auth.shared.handlers.AuthHandler {
 
                         if (mapItem.getItemMeta() instanceof MapMeta) {
                             MapMeta mapMeta = (MapMeta) mapItem.getItemMeta();
-
                             if (mapMeta != null) {
                                 mapMeta.setMapId(view.getId());
                                 mapItem.setItemMeta(mapMeta);

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/ConfigHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/ConfigHandler.java
@@ -1,8 +1,8 @@
 package com.lielamar.auth.bukkit.handlers;
 
+import com.lielamar.auth.bukkit.utils.file.FileManager;
 import com.lielamar.auth.shared.communication.CommunicationMethod;
 import com.lielamar.auth.shared.storage.StorageMethod;
-import com.lielamar.lielsutils.bukkit.files.FileManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -39,7 +39,6 @@ public final class ConfigHandler extends com.lielamar.auth.shared.handlers.Confi
 
     protected long reloadDelay = 0;
 
-    protected String qrCodeURL = "https://www.google.com/chart?chs=128x128&cht=qr&chl=otpauth://totp/";
     protected String ipHashType = "SHA256";
 
     protected boolean requireOnIPChange = true;
@@ -75,10 +74,6 @@ public final class ConfigHandler extends com.lielamar.auth.shared.handlers.Confi
 
     public long getReloadDelay() {
         return this.reloadDelay;
-    }
-
-    public String getQrCodeURL() {
-        return this.qrCodeURL;
     }
 
     public String getIpHashType() {
@@ -283,13 +278,6 @@ public final class ConfigHandler extends com.lielamar.auth.shared.handlers.Confi
             });
         } else {
             super.blacklistedCommands = config.getStringList("blacklisted-commands");
-        }
-
-        if (!config.contains("qr-code-service")) {
-            config.set("qr-code-service", this.qrCodeURL);
-            config.addComment("qr-code-service", "# Service to use when generating QR codes");
-        } else {
-            this.qrCodeURL = config.getString("qr-code-service");
         }
 
         if (!config.contains("check-for-updates")) {

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/DependencyHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/DependencyHandler.java
@@ -22,22 +22,23 @@ public class DependencyHandler {
 
         loader.addMavenCentral();
 
-        String googleAuthVersion = "1.5.0";
-        String commonsCodecVersion = "1.15";
-        String hikariCpVersion = "4.0.3";
-        String h2Version = "2.1.212";
-        String mysqlVersion = "8.0.29";
-        String mariaDBVersion = "2.7.3";
-        String postgresVersion = "42.3.6";
-        String mongoDBVersion = "3.12.11";
-        String slf4jVersion = "2.0.0-alpha7";
-        String log4jVersion = "2.18.0";
 
-        Bukkit.getServer().getLogger().info("Loading library Google Auth v" + googleAuthVersion);
+        String commonsCodecVersion = "1.17.0"; // Updated to match Gradle build file
+        String hikariCpVersion = "5.1.0"; // Updated to match Gradle build file
+        String h2Version = "2.2.224"; // Updated to match Gradle build file
+        String mysqlVersion = "8.4.0"; // Updated to match Gradle build file
+        String mariaDBVersion = "3.4.0"; // Updated to match Gradle build file
+        String postgresVersion = "42.7.3"; // Updated to match Gradle build file
+        String mongoDBVersion = "5.1.1"; // Updated to match Gradle build file
+        String slf4jVersion = "2.0.13"; // Updated to match Gradle build file
+        String log4jVersion = "2.23.1"; // Updated to match Gradle build file
+        String atlassianVersion = "2.1.1"; // Added Atlassian library
+
+        Bukkit.getServer().getLogger().info("Loading library Atlassian v" + atlassianVersion);
         Library library = Library.builder()
-                .groupId("com.warrenstrange")
-                .artifactId("googleauth")
-                .version(googleAuthVersion)
+                .groupId("com.atlassian")
+                .artifactId("onetime")
+                .version(atlassianVersion)
                 .build();
         loader.loadLibrary(library);
 
@@ -68,7 +69,7 @@ public class DependencyHandler {
         Bukkit.getServer().getLogger().info("Loading library MySQL v" + mysqlVersion);
         library = Library.builder()
                 .groupId("mysql")
-                .artifactId("mysql-connector-java")
+                .artifactId("mysql-connector-j")
                 .version(mysqlVersion)
                 .build();
         loader.loadLibrary(library);
@@ -92,7 +93,7 @@ public class DependencyHandler {
         Bukkit.getServer().getLogger().info("Loading library MongoDB v" + mongoDBVersion);
         library = Library.builder()
                 .groupId("org.mongodb")
-                .artifactId("mongo-java-driver")
+                .artifactId("mongodb-driver-sync")
                 .version(mongoDBVersion)
                 .build();
         loader.loadLibrary(library);
@@ -105,7 +106,7 @@ public class DependencyHandler {
                 .build();
         loader.loadLibrary(library);
 
-        Bukkit.getServer().getLogger().info("Loading library Log4j v" + slf4jVersion);
+        Bukkit.getServer().getLogger().info("Loading library Log4j v" + log4jVersion);
         library = Library.builder()
                 .groupId("org.apache.logging.log4j")
                 .artifactId("log4j-core")

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/DependencyHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/DependencyHandler.java
@@ -22,7 +22,7 @@ public class DependencyHandler {
 
         loader.addMavenCentral();
 
-
+        String kotlinStdLibVersion = "2.0.0"; // Added STDLib to allow atlassian library to run properly.
         String commonsCodecVersion = "1.17.0"; // Updated to match Gradle build file
         String hikariCpVersion = "5.1.0"; // Updated to match Gradle build file
         String h2Version = "2.2.224"; // Updated to match Gradle build file
@@ -34,8 +34,16 @@ public class DependencyHandler {
         String log4jVersion = "2.23.1"; // Updated to match Gradle build file
         String atlassianVersion = "2.1.1"; // Added Atlassian library
 
-        Bukkit.getServer().getLogger().info("Loading library Atlassian v" + atlassianVersion);
+        Bukkit.getServer().getLogger().info("Loading library Kotlin-StandardLib v" + atlassianVersion);
         Library library = Library.builder()
+                .groupId("org.jetbrains.kotlin")
+                .artifactId("kotlin-stdlib")
+                .version(kotlinStdLibVersion)
+                .build();
+        loader.loadLibrary(library);
+
+        Bukkit.getServer().getLogger().info("Loading library OneTime v" + atlassianVersion);
+        library = Library.builder()
                 .groupId("com.atlassian")
                 .artifactId("onetime")
                 .version(atlassianVersion)

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/MessageHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/MessageHandler.java
@@ -1,12 +1,13 @@
 package com.lielamar.auth.bukkit.handlers;
 
-import com.lielamar.lielsutils.bukkit.color.ColorUtils;
-import com.lielamar.lielsutils.bukkit.files.FileManager;
+import com.lielamar.auth.shared.utils.color.ColorUtils;
+import com.lielamar.auth.bukkit.utils.file.FileManager;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -54,7 +55,7 @@ public final class MessageHandler extends com.lielamar.auth.shared.handlers.Mess
         String finalMessage = ColorUtils.translateAlternateColorCodes('&', rawPrefix + rawMessage);
 
         TextComponent component = new TextComponent(finalMessage);
-        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(hoverAction).create()));
+        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder(hoverAction).create())));
         player.spigot().sendMessage(component);
     }
 

--- a/src/main/java/com/lielamar/auth/bukkit/handlers/MessageHandler.java
+++ b/src/main/java/com/lielamar/auth/bukkit/handlers/MessageHandler.java
@@ -55,7 +55,7 @@ public final class MessageHandler extends com.lielamar.auth.shared.handlers.Mess
         String finalMessage = ColorUtils.translateAlternateColorCodes('&', rawPrefix + rawMessage);
 
         TextComponent component = new TextComponent(finalMessage);
-        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(new ComponentBuilder(hoverAction).create())));
+        component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(hoverAction).create()));
         player.spigot().sendMessage(component);
     }
 

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -4,7 +4,7 @@ import com.lielamar.auth.bukkit.TwoFactorAuthentication;
 import com.lielamar.auth.bukkit.handlers.MessageHandler;
 import com.lielamar.auth.shared.handlers.AuthHandler;
 import com.lielamar.auth.shared.utils.Constants;
-import com.lielamar.lielsutils.numbers.NumbersUtils;
+import com.lielamar.auth.shared.utils.NumbersUtils;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/DisabledEvents.java
@@ -5,6 +5,7 @@ import com.lielamar.auth.bukkit.handlers.MessageHandler;
 import com.lielamar.auth.shared.handlers.AuthHandler;
 import com.lielamar.auth.shared.utils.Constants;
 import com.lielamar.auth.shared.utils.NumbersUtils;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -14,6 +15,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
@@ -101,12 +103,13 @@ public class DisabledEvents implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
-    public void onItemPickup(PlayerPickupItemEvent event) {
-        if (!this.plugin.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)) {
+    public void onItemPickup(EntityPickupItemEvent event) {
+        if (!this.plugin.getConfigHandler().getDisabledEvents().getOrDefault(event.getClass(), true)
+                || !event.getEntityType().equals(EntityType.PLAYER)) {
             return;
         }
 
-        if (this.plugin.getAuthHandler().needsToAuthenticate(event.getPlayer().getUniqueId())) {
+        if (this.plugin.getAuthHandler().needsToAuthenticate(event.getEntity().getUniqueId())) {
             event.setCancelled(true);
         } else if (this.plugin.getAuthHandler().isQRCodeItem(event.getItem().getItemStack())) {
             event.getItem().remove();

--- a/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
+++ b/src/main/java/com/lielamar/auth/bukkit/listeners/OnAuthStateChange.java
@@ -46,7 +46,7 @@ public class OnAuthStateChange implements Listener {
             this.plugin.getStorageHandler().setIP(event.getPlayer().getUniqueId(),
                     this.hash.hash(event.getPlayer().getAddress().getAddress().getHostAddress()));
 
-            this.plugin.getAuthTracker().setAuthentications(this.plugin.getAuthTracker().getAuthentications() + 1);
+            this.plugin.getAuthTracker().incrementAuths();
         }
     }
 

--- a/src/main/java/com/lielamar/auth/bukkit/utils/TimeUtils.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/TimeUtils.java
@@ -1,0 +1,146 @@
+package com.lielamar.auth.bukkit.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeUtils {
+
+    private static final long MILLISECONDS_IN_SECOND = 1000;
+    private static final long MILLISECONDS_IN_MINUTE = 60000;
+    private static final long MILLISECONDS_IN_HOUR = 3600000;
+    private static final long MILLISECONDS_IN_DAY = 86400000;
+    private static final long MILLISECONDS_IN_WEEK = 604800000;
+    private static final long MILLISECONDS_IN_MONTH = 2592000000L;
+    private static final long MILLISECONDS_IN_YEAR = 31536000000L;
+
+    /**
+     * Returns the current date
+     *
+     * @param pattern   Pattern to use
+     * @return          Current date (String Format)
+     */
+    public static @NotNull String getDate(@NotNull String pattern) {
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
+        return dtf.format(LocalDateTime.now());
+    }
+
+    /**
+     * Parses time given in string into milliseconds as long
+     * Example: 1y2m -> 100000
+     *
+     * @param time        Time to parse
+     * @return            Parsed time as long
+     */
+    public static long parseTime(@NotNull String time) {
+        long milliseconds = 0;
+
+        char[] timeArray = time.toCharArray();
+
+        for(int i = 0; i < timeArray.length; i++) {
+            if(timeArray[i] == 's')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_SECOND);
+            else if(timeArray[i] == 'm')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_MINUTE);
+            else if(timeArray[i] == 'h')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_HOUR);
+            else if(timeArray[i] == 'd')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_DAY);
+            else if(timeArray[i] == 'w')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_WEEK);
+            else if(timeArray[i] == 'M')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_MONTH);
+            else if(timeArray[i] == 'y')
+                milliseconds += parseSpecificTime(timeArray, i, MILLISECONDS_IN_YEAR);
+        }
+
+        return milliseconds;
+    }
+
+    /**
+     * Util function to parse a specific time in string
+     * Example: 1y -> 90000
+     *
+     * @param timeArray              Array of characters to parse
+     * @param index                  Current index in the array
+     * @param millisecondsModifier   Modifier to milliseconds - by how much does this function need to multiply the result to turn it to milliseconds
+     * @return                       Parsed specific time as long
+     */
+    private static long parseSpecificTime(char[] timeArray, int index, long millisecondsModifier) {
+        long milliseconds = 0;
+
+        int j = index - 1;
+        int counter = 1;
+
+        while(j >= 0 && Character.isDigit(timeArray[j])) {
+            milliseconds += counter * Integer.parseInt(timeArray[j] + "") * millisecondsModifier;
+            counter = counter * 10;
+            j--;
+        }
+
+        return milliseconds;
+    }
+
+    /**
+     * Parses time given in milliseconds into text as string
+     * Example: 100000 -> 1 year, 2 months etc.
+     *
+     * @param time        Time to parse
+     * @return            Parsed time as string
+     */
+    public static String parseTime(long time) {
+        if(time < 0)
+            return "Forever";
+
+        long years = time/MILLISECONDS_IN_YEAR;
+        time -= MILLISECONDS_IN_YEAR * years;
+
+        long months = time/MILLISECONDS_IN_MONTH;
+        time -= MILLISECONDS_IN_MONTH * months;
+
+        long weeks = time/MILLISECONDS_IN_WEEK;
+        time -= MILLISECONDS_IN_WEEK * weeks;
+
+        long days = time/MILLISECONDS_IN_DAY;
+        time -= MILLISECONDS_IN_DAY * days;
+
+        long hours = time/MILLISECONDS_IN_HOUR;
+        time -= MILLISECONDS_IN_HOUR * hours;
+
+        long minutes = time/MILLISECONDS_IN_MINUTE;
+        time -= MILLISECONDS_IN_MINUTE * minutes;
+
+        long seconds = time/MILLISECONDS_IN_SECOND;
+
+        StringBuilder finalTime = new StringBuilder();
+        if(years > 0) finalTime.append(years).append(" years, ");
+        if(months > 0) finalTime.append(months).append(" months, ");
+        if(weeks > 0) finalTime.append(weeks).append(" weeks, ");
+        if(days > 0) finalTime.append(days).append(" days, ");
+        if(hours > 0) finalTime.append(hours).append(" hours, ");
+        if(minutes > 0) finalTime.append(minutes).append(" minutes, ");
+        if(seconds > 0) finalTime.append(seconds).append(" seconds, ");
+
+        return finalTime.substring(0, finalTime.length() - 2);
+    }
+
+    /**
+     * Formats X seconds to the following format: XX:XX
+     *
+     * @param seconds        Seconds to format
+     * @return               Time left in the XX:XX format
+     */
+    public static @NotNull String formatSeconds(int seconds) {
+        int minutes = seconds/60;
+        seconds = seconds%60;
+
+        String sMinutes = minutes + "";
+        String sSeconds = seconds + "";
+
+        if(minutes < 10) sMinutes = "0" + minutes;
+        if(seconds < 10) sSeconds = "0" + seconds;
+
+        return sMinutes + ":" + sSeconds;
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/arrays/ArraysUtils.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/arrays/ArraysUtils.java
@@ -1,0 +1,17 @@
+package com.lielamar.auth.bukkit.utils.arrays;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ArraysUtils {
+
+    public static String[] removeFirstElement(@NotNull String[] arguments) {
+        if(arguments.length <= 1)
+            return new String[0];
+
+        String[] placeholder = new String[arguments.length - 1];
+        for(int i = 0; i < placeholder.length; i++)
+            placeholder[i] = arguments[i+1];
+
+        return placeholder;
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/bstats/BukkitMetrics.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/bstats/BukkitMetrics.java
@@ -1,0 +1,852 @@
+package com.lielamar.auth.bukkit.utils.bstats;/*
+ * This Metrics class was auto-generated and can be copied into your project if you are
+ * not using a build tool like Gradle or Maven for dependency management.
+ *
+ * IMPORTANT: You are not allowed to modify this class, except changing the package.
+ *
+ * Unallowed modifications include but are not limited to:
+ *  - Remove the option for users to opt-out
+ *  - Change the frequency for data submission
+ *  - Obfuscate the code (every obfucator should allow you to make an exception for specific files)
+ *  - Reformat the code (if you use a linter, add an exception)
+ *
+ * Violations will result in a ban of your plugin and account from bStats.
+ */
+
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.*;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+
+public class BukkitMetrics {
+
+    private final Plugin plugin;
+
+    private final MetricsBase metricsBase;
+
+    /**
+     * Creates a new Metrics instance.
+     *
+     * @param plugin Your plugin instance.
+     * @param serviceId The id of the service. It can be found at <a
+     *     href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
+     */
+    public BukkitMetrics(JavaPlugin plugin, int serviceId) {
+        this.plugin = plugin;
+        // Get the config file
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        File configFile = new File(bStatsFolder, "config.yml");
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+        if (!config.isSet("serverUuid")) {
+            config.addDefault("enabled", true);
+            config.addDefault("serverUuid", UUID.randomUUID().toString());
+            config.addDefault("logFailedRequests", false);
+            config.addDefault("logSentData", false);
+            config.addDefault("logResponseStatusText", false);
+            // Inform the server owners about bStats
+            config
+                    .options()
+                    .header(
+                            "bStats (https://bStats.org) collects some basic information for plugin authors, like how\n"
+                                    + "many people use their plugin and their total player count. It's recommended to keep bStats\n"
+                                    + "enabled, but if you're not comfortable with this, you can turn this setting off. There is no\n"
+                                    + "performance penalty associated with having metrics enabled, and data sent to bStats is fully\n"
+                                    + "anonymous.")
+                    .copyDefaults(true);
+            try {
+                config.save(configFile);
+            } catch (IOException ignored) {
+            }
+        }
+        // Load the data
+        boolean enabled = config.getBoolean("enabled", true);
+        String serverUUID = config.getString("serverUuid");
+        boolean logErrors = config.getBoolean("logFailedRequests", false);
+        boolean logSentData = config.getBoolean("logSentData", false);
+        boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
+        metricsBase =
+                new MetricsBase(
+                        "bukkit",
+                        serverUUID,
+                        serviceId,
+                        enabled,
+                        this::appendPlatformData,
+                        this::appendServiceData,
+                        submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+                        plugin::isEnabled,
+                        (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
+                        (message) -> this.plugin.getLogger().log(Level.INFO, message),
+                        logErrors,
+                        logSentData,
+                        logResponseStatusText);
+    }
+
+    /**
+     * Adds a custom chart.
+     *
+     * @param chart The chart to add.
+     */
+    public void addCustomChart(CustomChart chart) {
+        metricsBase.addCustomChart(chart);
+    }
+
+    private void appendPlatformData(JsonObjectBuilder builder) {
+        builder.appendField("playerAmount", getPlayerAmount());
+        builder.appendField("onlineMode", Bukkit.getOnlineMode() ? 1 : 0);
+        builder.appendField("bukkitVersion", Bukkit.getVersion());
+        builder.appendField("bukkitName", Bukkit.getName());
+        builder.appendField("javaVersion", System.getProperty("java.version"));
+        builder.appendField("osName", System.getProperty("os.name"));
+        builder.appendField("osArch", System.getProperty("os.arch"));
+        builder.appendField("osVersion", System.getProperty("os.version"));
+        builder.appendField("coreCount", Runtime.getRuntime().availableProcessors());
+    }
+
+    private void appendServiceData(JsonObjectBuilder builder) {
+        builder.appendField("pluginVersion", plugin.getDescription().getVersion());
+    }
+
+    private int getPlayerAmount() {
+        try {
+            // Around MC 1.8 the return type was changed from an array to a collection,
+            // This fixes java.lang.NoSuchMethodError:
+            // org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
+            Method onlinePlayersMethod = Class.forName("org.bukkit.Server").getMethod("getOnlinePlayers");
+            return onlinePlayersMethod.getReturnType().equals(Collection.class)
+                    ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()
+                    : ((Player[]) onlinePlayersMethod.invoke(Bukkit.getServer())).length;
+        } catch (Exception e) {
+            // Just use the new method if the reflection failed
+            return Bukkit.getOnlinePlayers().size();
+        }
+    }
+
+    public static class MetricsBase {
+
+        /** The version of the Metrics class. */
+        public static final String METRICS_VERSION = "3.0.0";
+
+        private static final ScheduledExecutorService scheduler =
+                Executors.newScheduledThreadPool(1, task -> new Thread(task, "bStats-Metrics"));
+
+        private static final String REPORT_URL = "https://bStats.org/api/v2/data/%s";
+
+        private final String platform;
+
+        private final String serverUuid;
+
+        private final int serviceId;
+
+        private final Consumer<JsonObjectBuilder> appendPlatformDataConsumer;
+
+        private final Consumer<JsonObjectBuilder> appendServiceDataConsumer;
+
+        private final Consumer<Runnable> submitTaskConsumer;
+
+        private final Supplier<Boolean> checkServiceEnabledSupplier;
+
+        private final BiConsumer<String, Throwable> errorLogger;
+
+        private final Consumer<String> infoLogger;
+
+        private final boolean logErrors;
+
+        private final boolean logSentData;
+
+        private final boolean logResponseStatusText;
+
+        private final Set<CustomChart> customCharts = new HashSet<>();
+
+        private final boolean enabled;
+
+        /**
+         * Creates a new MetricsBase class instance.
+         *
+         * @param platform The platform of the service.
+         * @param serviceId The id of the service.
+         * @param serverUuid The server uuid.
+         * @param enabled Whether or not data sending is enabled.
+         * @param appendPlatformDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+         *     appends all platform-specific data.
+         * @param appendServiceDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+         *     appends all service-specific data.
+         * @param submitTaskConsumer A consumer that takes a runnable with the submit task. This can be
+         *     used to delegate the data collection to a another thread to prevent errors caused by
+         *     concurrency. Can be {@code null}.
+         * @param checkServiceEnabledSupplier A supplier to check if the service is still enabled.
+         * @param errorLogger A consumer that accepts log message and an error.
+         * @param infoLogger A consumer that accepts info log messages.
+         * @param logErrors Whether or not errors should be logged.
+         * @param logSentData Whether or not the sent data should be logged.
+         * @param logResponseStatusText Whether or not the response status text should be logged.
+         */
+        public MetricsBase(
+                String platform,
+                String serverUuid,
+                int serviceId,
+                boolean enabled,
+                Consumer<JsonObjectBuilder> appendPlatformDataConsumer,
+                Consumer<JsonObjectBuilder> appendServiceDataConsumer,
+                Consumer<Runnable> submitTaskConsumer,
+                Supplier<Boolean> checkServiceEnabledSupplier,
+                BiConsumer<String, Throwable> errorLogger,
+                Consumer<String> infoLogger,
+                boolean logErrors,
+                boolean logSentData,
+                boolean logResponseStatusText) {
+            this.platform = platform;
+            this.serverUuid = serverUuid;
+            this.serviceId = serviceId;
+            this.enabled = enabled;
+            this.appendPlatformDataConsumer = appendPlatformDataConsumer;
+            this.appendServiceDataConsumer = appendServiceDataConsumer;
+            this.submitTaskConsumer = submitTaskConsumer;
+            this.checkServiceEnabledSupplier = checkServiceEnabledSupplier;
+            this.errorLogger = errorLogger;
+            this.infoLogger = infoLogger;
+            this.logErrors = logErrors;
+            this.logSentData = logSentData;
+            this.logResponseStatusText = logResponseStatusText;
+            checkRelocation();
+            if (enabled) {
+                // WARNING: Removing the option to opt-out will get your plugin banned from bStats
+                startSubmitting();
+            }
+        }
+
+        public void addCustomChart(CustomChart chart) {
+            this.customCharts.add(chart);
+        }
+
+        private void startSubmitting() {
+            final Runnable submitTask =
+                    () -> {
+                        if (!enabled || !checkServiceEnabledSupplier.get()) {
+                            // Submitting data or service is disabled
+                            scheduler.shutdown();
+                            return;
+                        }
+                        if (submitTaskConsumer != null) {
+                            submitTaskConsumer.accept(this::submitData);
+                        } else {
+                            this.submitData();
+                        }
+                    };
+            // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution
+            // of requests on the
+            // bStats backend. To circumvent this problem, we introduce some randomness into the initial
+            // and second delay.
+            // WARNING: You must not modify and part of this Metrics class, including the submit delay or
+            // frequency!
+            // WARNING: Modifying this code will get your plugin banned on bStats. Just don't do it!
+            long initialDelay = (long) (1000 * 60 * (3 + Math.random() * 3));
+            long secondDelay = (long) (1000 * 60 * (Math.random() * 30));
+            scheduler.schedule(submitTask, initialDelay, TimeUnit.MILLISECONDS);
+            scheduler.scheduleAtFixedRate(
+                    submitTask, initialDelay + secondDelay, 1000 * 60 * 30, TimeUnit.MILLISECONDS);
+        }
+
+        private void submitData() {
+            final JsonObjectBuilder baseJsonBuilder = new JsonObjectBuilder();
+            appendPlatformDataConsumer.accept(baseJsonBuilder);
+            final JsonObjectBuilder serviceJsonBuilder = new JsonObjectBuilder();
+            appendServiceDataConsumer.accept(serviceJsonBuilder);
+            JsonObjectBuilder.JsonObject[] chartData =
+                    customCharts.stream()
+                            .map(customChart -> customChart.getRequestJsonObject(errorLogger, logErrors))
+                            .filter(Objects::nonNull)
+                            .toArray(JsonObjectBuilder.JsonObject[]::new);
+            serviceJsonBuilder.appendField("id", serviceId);
+            serviceJsonBuilder.appendField("customCharts", chartData);
+            baseJsonBuilder.appendField("service", serviceJsonBuilder.build());
+            baseJsonBuilder.appendField("serverUUID", serverUuid);
+            baseJsonBuilder.appendField("metricsVersion", METRICS_VERSION);
+            JsonObjectBuilder.JsonObject data = baseJsonBuilder.build();
+            scheduler.execute(
+                    () -> {
+                        try {
+                            // Send the data
+                            sendData(data);
+                        } catch (Exception e) {
+                            // Something went wrong! :(
+                            if (logErrors) {
+                                errorLogger.accept("Could not submit bStats metrics data", e);
+                            }
+                        }
+                    });
+        }
+
+        private void sendData(JsonObjectBuilder.JsonObject data) throws Exception {
+            if (logSentData) {
+                infoLogger.accept("Sent bStats metrics data: " + data.toString());
+            }
+            String url = String.format(REPORT_URL, platform);
+            HttpsURLConnection connection = (HttpsURLConnection) new URL(url).openConnection();
+            // Compress the data to save bandwidth
+            byte[] compressedData = compress(data.toString());
+            connection.setRequestMethod("POST");
+            connection.addRequestProperty("Accept", "application/json");
+            connection.addRequestProperty("Connection", "close");
+            connection.addRequestProperty("Content-Encoding", "gzip");
+            connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("User-Agent", "Metrics-Service/1");
+            connection.setDoOutput(true);
+            try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+                outputStream.write(compressedData);
+            }
+            StringBuilder builder = new StringBuilder();
+            try (BufferedReader bufferedReader =
+                         new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    builder.append(line);
+                }
+            }
+            if (logResponseStatusText) {
+                infoLogger.accept("Sent data to bStats and received response: " + builder);
+            }
+        }
+
+        /** Checks that the class was properly relocated. */
+        private void checkRelocation() {
+            // You can use the property to disable the check in your test environment
+            if (System.getProperty("bstats.relocatecheck") == null
+                    || !System.getProperty("bstats.relocatecheck").equals("false")) {
+                // Maven's Relocate is clever and changes strings, too. So we have to use this little
+                // "trick" ... :D
+                final String defaultPackage =
+                        new String(new byte[] {'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
+                final String examplePackage =
+                        new String(new byte[] {'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
+                // We want to make sure no one just copy & pastes the example and uses the wrong package
+                // names
+                if (MetricsBase.class.getPackage().getName().startsWith(defaultPackage)
+                        || MetricsBase.class.getPackage().getName().startsWith(examplePackage)) {
+                    throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+                }
+            }
+        }
+
+        /**
+         * Gzips the given string.
+         *
+         * @param str The string to gzip.
+         * @return The gzipped string.
+         */
+        private static byte[] compress(final String str) throws IOException {
+            if (str == null) {
+                return null;
+            }
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+                gzip.write(str.getBytes(StandardCharsets.UTF_8));
+            }
+            return outputStream.toByteArray();
+        }
+    }
+
+    public static class DrilldownPie extends CustomChart {
+
+        private final Callable<Map<String, Map<String, Integer>>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        public JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Map<String, Integer>> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean reallyAllSkipped = true;
+            for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
+                JsonObjectBuilder valueBuilder = new JsonObjectBuilder();
+                boolean allSkipped = true;
+                for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
+                    valueBuilder.appendField(valueEntry.getKey(), valueEntry.getValue());
+                    allSkipped = false;
+                }
+                if (!allSkipped) {
+                    reallyAllSkipped = false;
+                    valuesBuilder.appendField(entryValues.getKey(), valueBuilder.build());
+                }
+            }
+            if (reallyAllSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class AdvancedPie extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class MultiLineChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class SimpleBarChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                valuesBuilder.appendField(entry.getKey(), new int[] {entry.getValue()});
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public abstract static class CustomChart {
+
+        private final String chartId;
+
+        protected CustomChart(String chartId) {
+            if (chartId == null) {
+                throw new IllegalArgumentException("chartId must not be null");
+            }
+            this.chartId = chartId;
+        }
+
+        public JsonObjectBuilder.JsonObject getRequestJsonObject(
+                BiConsumer<String, Throwable> errorLogger, boolean logErrors) {
+            JsonObjectBuilder builder = new JsonObjectBuilder();
+            builder.appendField("chartId", chartId);
+            try {
+                JsonObjectBuilder.JsonObject data = getChartData();
+                if (data == null) {
+                    // If the data is null we don't send the chart.
+                    return null;
+                }
+                builder.appendField("data", data);
+            } catch (Throwable t) {
+                if (logErrors) {
+                    errorLogger.accept("Failed to get data for custom chart with id " + chartId, t);
+                }
+                return null;
+            }
+            return builder.build();
+        }
+
+        protected abstract JsonObjectBuilder.JsonObject getChartData() throws Exception;
+    }
+
+    public static class SimplePie extends CustomChart {
+
+        private final Callable<String> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimplePie(String chartId, Callable<String> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            String value = callable.call();
+            if (value == null || value.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("value", value).build();
+        }
+    }
+
+    public static class AdvancedBarChart extends CustomChart {
+
+        private final Callable<Map<String, int[]>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, int[]> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, int[]> entry : map.entrySet()) {
+                if (entry.getValue().length == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class SingleLineChart extends CustomChart {
+
+        private final Callable<Integer> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SingleLineChart(String chartId, Callable<Integer> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            int value = callable.call();
+            if (value == 0) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("value", value).build();
+        }
+    }
+
+    /**
+     * An extremely simple JSON builder.
+     *
+     * <p>While this class is neither feature-rich nor the most performant one, it's sufficient enough
+     * for its use-case.
+     */
+    public static class JsonObjectBuilder {
+
+        private StringBuilder builder = new StringBuilder();
+
+        private boolean hasAtLeastOneField = false;
+
+        public JsonObjectBuilder() {
+            builder.append("{");
+        }
+
+        /**
+         * Appends a null field to the JSON.
+         *
+         * @param key The key of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendNull(String key) {
+            appendFieldUnescaped(key, "null");
+            return this;
+        }
+
+        /**
+         * Appends a string field to the JSON.
+         *
+         * @param key The key of the field.
+         * @param value The value of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, String value) {
+            if (value == null) {
+                throw new IllegalArgumentException("JSON value must not be null");
+            }
+            appendFieldUnescaped(key, "\"" + escape(value) + "\"");
+            return this;
+        }
+
+        /**
+         * Appends an integer field to the JSON.
+         *
+         * @param key The key of the field.
+         * @param value The value of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, int value) {
+            appendFieldUnescaped(key, String.valueOf(value));
+            return this;
+        }
+
+        /**
+         * Appends an object to the JSON.
+         *
+         * @param key The key of the field.
+         * @param object The object.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, JsonObject object) {
+            if (object == null) {
+                throw new IllegalArgumentException("JSON object must not be null");
+            }
+            appendFieldUnescaped(key, object.toString());
+            return this;
+        }
+
+        /**
+         * Appends a string array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The string array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, String[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values)
+                            .map(value -> "\"" + escape(value) + "\"")
+                            .collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends an integer array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The integer array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, int[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values).mapToObj(String::valueOf).collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends an object array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The integer array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, JsonObject[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values).map(JsonObject::toString).collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends a field to the object.
+         *
+         * @param key The key of the field.
+         * @param escapedValue The escaped value of the field.
+         */
+        private void appendFieldUnescaped(String key, String escapedValue) {
+            if (builder == null) {
+                throw new IllegalStateException("JSON has already been built");
+            }
+            if (key == null) {
+                throw new IllegalArgumentException("JSON key must not be null");
+            }
+            if (hasAtLeastOneField) {
+                builder.append(",");
+            }
+            builder.append("\"").append(escape(key)).append("\":").append(escapedValue);
+            hasAtLeastOneField = true;
+        }
+
+        /**
+         * Builds the JSON string and invalidates this builder.
+         *
+         * @return The built JSON string.
+         */
+        public JsonObject build() {
+            if (builder == null) {
+                throw new IllegalStateException("JSON has already been built");
+            }
+            JsonObject object = new JsonObject(builder.append("}").toString());
+            builder = null;
+            return object;
+        }
+
+        /**
+         * Escapes the given string like stated in https://www.ietf.org/rfc/rfc4627.txt.
+         *
+         * <p>This method escapes only the necessary characters '"', '\'. and '\u0000' - '\u001F'.
+         * Compact escapes are not used (e.g., '\n' is escaped as "\u000a" and not as "\n").
+         *
+         * @param value The value to escape.
+         * @return The escaped value.
+         */
+        private static String escape(String value) {
+            final StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '"') {
+                    builder.append("\\\"");
+                } else if (c == '\\') {
+                    builder.append("\\\\");
+                } else if (c <= '\u000F') {
+                    builder.append("\\u000").append(Integer.toHexString(c));
+                } else if (c <= '\u001F') {
+                    builder.append("\\u00").append(Integer.toHexString(c));
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
+
+        /**
+         * A super simple representation of a JSON object.
+         *
+         * <p>This class only exists to make methods of the {@link JsonObjectBuilder} type-safe and not
+         * allow a raw string inputs for methods like {@link JsonObjectBuilder#appendField(String,
+         * JsonObject)}.
+         */
+        public static class JsonObject {
+
+            private final String value;
+
+            private JsonObject(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/CheckPermissionCallback.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/CheckPermissionCallback.java
@@ -1,0 +1,8 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import org.bukkit.command.CommandSender;
+
+public interface CheckPermissionCallback {
+
+    boolean hasPermission(CommandSender commandSender);
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/Command.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/Command.java
@@ -1,0 +1,55 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public abstract class Command {
+
+    protected String command;
+    protected @Nullable String permission;
+    protected @Nullable CheckPermissionCallback checkPermissionCallback;
+
+    public Command(@NotNull String command, @Nullable String permission) {
+        this.command = command;
+        this.permission = permission;
+    }
+
+    public Command(@NotNull String command, @Nullable CheckPermissionCallback checkPermissionCallback) {
+        this.command = command;
+        this.checkPermissionCallback = checkPermissionCallback;
+    }
+
+
+    public abstract void noPermissionEvent(@NotNull CommandSender cs);
+    public abstract boolean runCommand(@NotNull CommandSender cs, @NotNull String[] args);
+    public abstract List<String> tabOptions(@NotNull CommandSender cs, @NotNull String[] args);
+
+    public abstract @NotNull String getUsage();
+    public abstract @NotNull String getDescription();
+    public abstract @NotNull String[] getAliases();
+
+
+    public final @NotNull String getCommandName() { return command; }
+    public final @Nullable String getPermission() { return permission; }
+
+
+    public final boolean hasPermission(@NotNull CommandSender cs) {
+        if(this.permission == null && this.checkPermissionCallback == null)
+            return false;
+
+        if(this.permission != null)
+            return cs.hasPermission(this.permission);
+
+        return this.checkPermissionCallback.hasPermission(cs);
+    }
+
+    public final void execute(CommandSender cs, @NotNull String[] args) {
+        if(this.hasPermission(cs))
+            this.runCommand(cs, args);
+        else
+            this.noPermissionEvent(cs);
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/CommandWithSubCommands.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/CommandWithSubCommands.java
@@ -1,0 +1,37 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class CommandWithSubCommands extends Command {
+
+    public CommandWithSubCommands(@NotNull String name, @Nullable String permission) {
+        super(name, permission);
+    }
+
+    public CommandWithSubCommands(@NotNull String name, @Nullable CheckPermissionCallback checkPermissionCallback) {
+        super(name, checkPermissionCallback);
+    }
+
+
+    public abstract void subCommandNotFoundEvent(@NotNull CommandSender cs);
+    public abstract @NotNull Command[] getSubCommands();
+
+
+    public @Nullable Command getSubCommand(@NotNull String name) {
+        for(Command subCommand : getSubCommands()) {
+            if(subCommand.getCommandName().equalsIgnoreCase(name))
+                return subCommand;
+
+            if(subCommand.getAliases() != null) {
+                for(String alias : subCommand.getAliases()) {
+                    if(alias.equalsIgnoreCase(name))
+                        return subCommand;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/ParentCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/ParentCommand.java
@@ -1,0 +1,77 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import com.lielamar.auth.bukkit.utils.arrays.ArraysUtils;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class ParentCommand extends CommandWithSubCommands {
+
+    public ParentCommand(@NotNull String name, @Nullable String permission) { super(name, permission); }
+    public ParentCommand(@NotNull String name, @Nullable CheckPermissionCallback checkPermissionCallback) { super(name, checkPermissionCallback); }
+
+
+    public abstract boolean runMasterCommand(@NotNull CommandSender commandSender, @NotNull String[] args);
+    public abstract List<String> maserTabOptions(@NotNull CommandSender commandSender, @NotNull String[] args);
+
+
+    @Override
+    public final boolean runCommand(@NotNull CommandSender commandSender, @NotNull String[] args) {
+        // Tries to run the subcommand first, then trying to run the master command if no sub command was ran.
+
+        if(super.hasPermission(commandSender)) {
+            if(args.length != 0) {
+                Command subCommand = this.getSubCommand(args[0]);
+
+                if(subCommand != null) {
+                    if(subCommand.hasPermission(commandSender))
+                        return subCommand.runCommand(commandSender, (getSubCommands().length > 0 ? ArraysUtils.removeFirstElement(args.clone()) : args.clone()));
+                    else {
+                        subCommand.noPermissionEvent(commandSender);
+                        return false;
+                    }
+                }
+            }
+
+            return runMasterCommand(commandSender, args.clone());
+        }
+
+        noPermissionEvent(commandSender);
+        return false;
+    }
+
+    @Override
+    public List<String> tabOptions(@NotNull CommandSender commandSender, @NotNull String[] args) {
+        List<String> options = new ArrayList<>();
+
+        if(super.hasPermission(commandSender)) {
+            if(args.length == 0)
+                return this.maserTabOptions(commandSender, args.clone());
+
+            Command subCommand = getSubCommand(args[0]);
+
+            if(subCommand != null)
+                return subCommand.tabOptions(commandSender, (getSubCommands().length > 0 ? ArraysUtils.removeFirstElement(args.clone()) : args.clone()));
+
+            List<String> opt = this.maserTabOptions(commandSender, args.clone());
+            options.addAll(opt == null ? new ArrayList<>() : opt);
+
+            for(Command subCmd : getSubCommands()) {
+                if(subCmd.getPermission() == null || commandSender.hasPermission(subCmd.getPermission())) {
+                    if(subCmd.getCommandName().toLowerCase().startsWith(args[0].toLowerCase()))
+                        options.add(subCmd.getCommandName());
+
+                    Arrays.stream(subCmd.getAliases())
+                            .filter(alias -> alias.toLowerCase().startsWith(args[0].toLowerCase()))
+                            .forEach(options::add);
+                }
+            }
+        }
+
+        return options;
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/StandaloneCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/StandaloneCommand.java
@@ -1,0 +1,30 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class StandaloneCommand extends SuperCommand {
+
+    public StandaloneCommand(@NotNull String command, @Nullable String permission) {
+        super(command, permission);
+    }
+    public StandaloneCommand(@NotNull String name, @Nullable CheckPermissionCallback checkPermissionCallback) { super(name, checkPermissionCallback); }
+
+
+    @Override
+    public final void subCommandNotFoundEvent(@NotNull CommandSender cs) {}
+
+    @Override
+    public final Command[] getSubCommands() { return new Command[0]; }
+
+
+    @Override
+    public @NotNull String getUsage() { return ""; }
+
+    @Override
+    public @NotNull String getDescription() { return ""; }
+
+    @Override
+    public @NotNull String[] getAliases() { return new String[0]; }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/SuperCommand.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/SuperCommand.java
@@ -1,0 +1,90 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import com.lielamar.auth.bukkit.utils.arrays.ArraysUtils;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class SuperCommand extends CommandWithSubCommands {
+
+    public SuperCommand(@NotNull String name, @Nullable String permission) {
+        super(name, permission);
+    }
+
+    public SuperCommand(@NotNull String name, @Nullable CheckPermissionCallback checkPermissionCallback) {
+        super(name, checkPermissionCallback);
+    }
+
+    public final void registerCommand(@NotNull JavaPlugin plugin) {
+        PluginCommand pluginCommand = plugin.getCommand(command);
+
+        if (pluginCommand == null) return;
+
+        pluginCommand.setTabCompleter((commandSender, command, _alias, args) -> {
+            List<String> options = new ArrayList<>();
+
+            // If the sender has permissions we want to return one of the following:
+            // 1. If the sender started entering an input, we want to return all sub commands that start with.
+            //      If we have a subcommand that is equals to an exact sub commands, we want to return the subcommand's tab options.
+            // 2. If the sender didn't enter anything, we want to add all of the options of the #tabOptions implementation, and loop over all subcommands and add all of them to the options
+            if (super.hasPermission(commandSender)) {
+                if (args.length == 0)
+                    return this.tabOptions(commandSender, args.clone());
+
+                Command subCommand = getSubCommand(args[0]);
+
+                if (subCommand != null)
+                    return subCommand.tabOptions(commandSender, (getSubCommands().length > 0 ? ArraysUtils.removeFirstElement(args.clone()) : args.clone()));
+
+                List<String> opt = this.tabOptions(commandSender, args.clone());
+                options.addAll(opt == null ? new ArrayList<>() : opt);
+
+                for (Command subCmd : getSubCommands()) {
+                    if (subCmd.getPermission() == null || commandSender.hasPermission(subCmd.getPermission())) {
+                        if (subCmd.getCommandName().toLowerCase().startsWith(args[0].toLowerCase()))
+                            options.add(subCmd.getCommandName());
+
+                        Arrays.stream(subCmd.getAliases())
+                                .filter(alias -> alias.toLowerCase().startsWith(args[0].toLowerCase()))
+                                .forEach(options::add);
+                    }
+                }
+            }
+
+            return options;
+        });
+
+        pluginCommand.setExecutor((commandSender, command, label, args) -> {
+            if (super.hasPermission(commandSender)) {
+                // If there are arguments we want to check if we have a subcommand corresponding to these arguments.
+                //   If so, we want to check if the sender has permission to that subcommand, and if so we want to run it
+                //   If not, we'll run the #noPermissionEvent of the subcommand
+                // If there are no arguments we want to run the master command, which is this the class extending this SuperCommand class.
+                //
+                // If the user doesn't have permission at all, we'll run the #noPermissionsEvent implementation of the master command, which is this the class extending this SuperCommand class.
+                if (args.length != 0) {
+                    Command subCommand = getSubCommand(args[0]);
+
+                    if (subCommand != null) {
+                        if (subCommand.hasPermission(commandSender))
+                            return subCommand.runCommand(commandSender, (getSubCommands().length > 0 ? ArraysUtils.removeFirstElement(args.clone()) : args.clone()));
+                        else {
+                            subCommand.noPermissionEvent(commandSender);
+                            return false;
+                        }
+                    }
+                }
+
+                return runCommand(commandSender, args.clone());
+            }
+
+            noPermissionEvent(commandSender);
+            return false;
+        });
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/cmd/TabOptionsBuilder.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/cmd/TabOptionsBuilder.java
@@ -1,0 +1,73 @@
+package com.lielamar.auth.bukkit.utils.cmd;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.HumanEntity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+public class TabOptionsBuilder {
+
+    private final List<Callable<List<String>>> argsF = new ArrayList<>();
+
+
+    public TabOptionsBuilder range(int min, int max, int jump) {
+        argsF.add(() -> {
+            List<String> r = new ArrayList<>();
+
+            for(int i = min; i < max; i += jump)
+                r.add(i + "");
+
+            return r;
+        });
+
+        return this;
+    }
+
+    public TabOptionsBuilder players() {
+        argsF.add(() -> Bukkit.getOnlinePlayers().stream().map(HumanEntity::getName).collect(Collectors.toList()));
+        return this;
+    }
+
+    public TabOptionsBuilder playerAnd(String... option) {
+        argsF.add(() -> {
+            List<String> r = Bukkit.getOnlinePlayers().stream().map(HumanEntity::getName).collect(Collectors.toList());
+            r.addAll(Arrays.asList(option));
+
+            return r;
+        });
+
+        return this;
+    }
+
+    public TabOptionsBuilder list(String... option) {
+        argsF.add(() -> Arrays.asList(option));
+        return this;
+    }
+
+    public List<String> build(String[] args) {
+        String lastArg = "";
+
+        int id = args.length;
+
+        if(id > 0) {
+            id -= 1;
+            lastArg = args[id];
+        }
+
+        if(id < argsF.size()) {
+            try {
+                String finalLastArg = lastArg;
+                return argsF.get(id).call().stream().filter(s -> s.toLowerCase().startsWith(finalLastArg.toLowerCase())).collect(Collectors.toList());
+            } catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/fetching/FetchingUtils.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/fetching/FetchingUtils.java
@@ -1,0 +1,46 @@
+package com.lielamar.auth.bukkit.utils.fetching;
+
+import com.lielamar.auth.bukkit.utils.uuid.InvalidResponseException;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class FetchingUtils {
+
+    /**
+     * Fetches a GET request to the given URL
+     *
+     * @param url        URL to fetch data from
+     * @param callback   Callback to call when a response is received
+     */
+    public static void fetch(@NotNull String url, @NotNull JSONCallback callback) throws InvalidResponseException {
+        callback.run(fetch(url));
+    }
+
+    public static @NotNull String fetch(@NotNull String url) throws InvalidResponseException {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setReadTimeout(5000);
+            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+
+            String inputLine;
+            StringBuilder response = new StringBuilder();
+
+            while((inputLine = in.readLine()) != null)
+                response.append(inputLine);
+            in.close();
+
+            if(response.length() == 0)
+                throw new InvalidResponseException("Returned data from the GET request was empty!");
+
+            return response.toString();
+        } catch(IOException exception) {
+            throw new InvalidResponseException("Fetching " + url + " failed for the following reason: " + exception.toString());
+        }
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/fetching/JSONCallback.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/fetching/JSONCallback.java
@@ -1,0 +1,7 @@
+package com.lielamar.auth.bukkit.utils.fetching;
+
+public interface JSONCallback {
+
+    void run(String json);
+
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/file/FileManager.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/file/FileManager.java
@@ -1,0 +1,444 @@
+package com.lielamar.auth.bukkit.utils.file;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+
+public class FileManager {
+
+    public static final String DEFAULT_HEADER_SEPARATOR = "# ===========================================================================================";
+    public static String HEADER_SEPARATOR;
+
+    private final JavaPlugin plugin;
+    private final Map<String, Config> configs;
+
+
+    public FileManager(@NotNull JavaPlugin plugin) {
+        this(plugin, DEFAULT_HEADER_SEPARATOR);
+    }
+
+    public FileManager(@NotNull JavaPlugin plugin, @NotNull String headerSeparator) {
+        this.plugin = plugin;
+        this.configs = new HashMap<>();
+
+        HEADER_SEPARATOR = headerSeparator;
+    }
+
+
+    /**
+     * Returns a Config object representing a single configuration
+     *
+     * @param path       Path to the config file
+     * @param fileName   Name of the config file
+     * @return           Config object representing the given config
+     */
+    public @Nullable Config getConfig(@NotNull String path, @NotNull String fileName) {
+        fileName = this.fixConfigName(fileName);
+
+        Config config = this.configs.get(fileName);
+        if(config != null)
+            return config;
+
+        File configFile = this.getConfigFile(path, fileName);
+
+        if(configFile == null)
+            return null;
+
+        // If the config doesn't already exist, we want to create it, copy the resource and set it's header
+        if(!configFile.exists())
+            this.createFile(configFile, this.plugin.getResource(fileName));
+
+        config = new Config(configFile);
+
+        this.configs.put(fileName, config);
+        return config;
+    }
+
+    public @Nullable Config getConfig(@NotNull String fileName) {
+        return this.getConfig(this.plugin.getDataFolder().getPath(), fileName);
+    }
+
+
+    /**
+     * Returns the File object of a config file
+     *
+     * @param path       Path to the config file
+     * @param fileName   Name of the config file
+     * @return           File object of the given config
+     */
+    private @Nullable File getConfigFile(@NotNull String path, @NotNull String fileName) {
+        if(fileName.isEmpty())
+            return null;
+
+        if(path.isEmpty())
+            return new File(this.plugin.getDataFolder() + File.separator + fileName);
+
+        if(!path.endsWith("/"))
+            path += File.separator;
+
+        return new File(path + fileName);
+    }
+
+    /**
+     * Creates a File object for a config file
+     *
+     * @param configFile   File to create
+     * @param source       Optional source to apply to the config
+     */
+    private void createFile(@NotNull File configFile, @Nullable InputStream source) {
+        if(configFile.exists())
+            return;
+
+        try {
+            boolean createdDir  = configFile.getParentFile().mkdir();
+            boolean createdFile = configFile.createNewFile();
+
+            if(source != null)
+                this.loadSource(configFile, source);
+
+        } catch(IOException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    /**
+     * Loads a source stream to a file
+     *
+     * @param configFile   File to load the source to
+     * @param source       Source to load
+     */
+    private void loadSource(@NotNull File configFile, @NotNull InputStream source) {
+        if(!configFile.exists())
+            return;
+
+        try {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(source, StandardCharsets.UTF_8));
+
+            OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8);
+
+            String line;
+            while((line = reader.readLine()) != null)
+                out.write(line + "\n");
+
+            out.close();
+            reader.close();
+            source.close();
+        } catch(IOException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Fixes a config name -> turns to lowercase & adds .yml in the end
+     *
+     * @param fileName   Name to fix
+     * @return           Fixed name
+     */
+    private @NotNull String fixConfigName(@NotNull String fileName) {
+        if(!fileName.toLowerCase().endsWith(".yml"))
+            fileName += ".yml";
+
+        return fileName.toLowerCase();
+    }
+
+
+    public static class Config {
+
+        private final File configFile;
+        private YamlConfiguration configuration;
+
+        private final List<String> header;
+        private final Map<String, List<String>> comments;
+
+        public Config(@NotNull File configFile) {
+            this.configFile = configFile;
+
+            this.header = new ArrayList<>();
+            this.comments = new HashMap<>();
+
+            this.loadConfig();
+        }
+
+        /**
+         * Loads the config:
+         * - Sets the configuration object's value
+         * - Loads header & all comments
+         */
+        private void loadConfig() {
+            if(!this.configFile.exists())
+                return;
+
+            try {
+                String currentLine;
+                boolean foundHeader = false; // Used to track when the header starts & stops
+
+                List<String> lines = Files.readAllLines(this.configFile.toPath(), StandardCharsets.UTF_8);
+                StringBuilder configData = new StringBuilder();
+
+                // Looping over the lines to parse the config
+                for(int i = 0; i < lines.size(); i++) {
+                    currentLine = lines.get(i);
+
+                    // If the current line is a header separator, we want to set foundHeader to the opposite value
+                    // This way, when the foundHeader is true, all comments will go to the header, until we find the next header separator
+                    if(currentLine.equals(HEADER_SEPARATOR)) {
+                        foundHeader = !foundHeader;
+                        header.add(currentLine);
+                        continue;
+                    }
+
+                    // If the current line is a comment, we either want to add it to the header if we're in the foundHeader state,
+                    // or add it to the map of comments, under the correct key.
+                    // We find the correct key by looping over all lines until we find the next key, and this key is the key the comment belongs to
+                    if(currentLine.startsWith("#") || currentLine.trim().startsWith("#")) {
+                        if(foundHeader)
+                            header.add(currentLine);
+                        else {
+                            // Trying to find the matching key for this comment by looping over all next lines until we find a line that isn't a comment
+                            int j = i;
+                            while(j < lines.size() && (lines.get(j).startsWith("#") || lines.get(j).trim().startsWith("#")))
+                                j++;
+
+                            // If we found a key, we want to put the currentLine as a comment for the found key
+                            if(j != i) {
+                                // The key contains all spaces before it, for example the key for the path test.hello would be "  hello", because it has 1 parent
+                                // This way, when saving the file, we can easily get the right key without needing the check the parents
+                                String key = lines.get(j).split(":")[0];
+
+                                // Adding the comment to the list of comments belong to the key
+                                if(comments.containsKey(key))
+                                    comments.get(key).add(currentLine);
+                                else {
+                                    List<String> listOfLines = new ArrayList<>();
+                                    listOfLines.add(currentLine);
+
+                                    comments.put(key, listOfLines);
+                                }
+                            }
+                        }
+                    } else
+                        // If the current line is not a comment we want to add it to the config data
+                        configData.append(currentLine).append("\n");
+                }
+
+                // Loading the configData into this.configuration through a reader
+                Reader inputString = new StringReader(configData.toString());
+                BufferedReader reader = new BufferedReader(inputString);
+
+                this.configuration = YamlConfiguration.loadConfiguration(reader);
+                inputString.close();
+                reader.close();
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+        }
+
+
+        public @Nullable Object get(@NotNull String path)                                    { return this.configuration.get(path); }
+        public @Nullable Object get(@NotNull String path, @NotNull Object defaultValue)       { return this.configuration.get(path, defaultValue); }
+
+        public @Nullable String getString(@NotNull String path)                              { return this.configuration.getString(path); }
+        public @Nullable String getString(@NotNull String path, @NotNull String defaultValue) { return this.configuration.getString(path, defaultValue); }
+
+        public int getInt(@NotNull String path)                                              { return this.configuration.getInt(path); }
+        public int getInt(@NotNull String path, int defaultValue)                            { return this.configuration.getInt(path, defaultValue); }
+
+        public double getDouble(@NotNull String path)                                        { return this.configuration.getDouble(path); }
+        public double getDouble(@NotNull String path, double defaultValue)                   { return this.configuration.getDouble(path, defaultValue); }
+
+        public boolean getBoolean(@NotNull String path)                                      { return this.configuration.getBoolean(path); }
+        public boolean getBoolean(@NotNull String path, boolean defaultValue)                { return this.configuration.getBoolean(path, defaultValue); }
+
+        public @Nullable List<?> getList(@NotNull String path)                               { return this.configuration.getList(path); }
+        public @Nullable List<?> getList(@NotNull String path, @NotNull List<?> defaultValue) { return this.configuration.getList(path, defaultValue); }
+
+        public @NotNull List<String> getStringList(@NotNull String path)                     { return this.configuration.getStringList(path); }
+        public @NotNull List<Integer> getIntegerList(@NotNull String path)                   { return this.configuration.getIntegerList(path); }
+
+        public @Nullable Set<String> getKeys()                                               { return this.configuration.getKeys(false); }
+
+        public @NotNull ConfigurationSection createSection(@NotNull String path)             { return this.configuration.createSection(path); }
+        public @Nullable ConfigurationSection getConfigurationSection(@NotNull String path)  { return this.configuration.getConfigurationSection(path); }
+
+        public boolean contains(@NotNull String path)                                        { return this.configuration.contains(path); }
+        public void removeKey(@NotNull String path)                                          { this.configuration.set(path, null); }
+        public void set(@NotNull String path, @Nullable Object value)                        { this.configuration.set(path, value); }
+
+
+        /**
+         * Returns a key from a path.
+         *
+         * If the path has any parents, we want to only get the children.
+         * We also want to add 2 spaces before the key, for every parent it has.
+         * This way, the key matches with the one from the initial load of the config (through #loadConfig)
+         *
+         * Example:
+         *   hello.i.am.liel
+         *   - 3 parents (hello, i, am)
+         *   - key is "liel"
+         *   - final key would have 6 spaces (3 parents * 2 spaces for each parent) -> "      liel"
+         *
+         * @param path   Path to get the key of
+         * @return       Key of the path
+         */
+        private @NotNull String getKeyFromPath(String path) {
+            StringBuilder key;
+
+            if(!path.contains("."))
+                key = new StringBuilder(path);
+            else {
+                String[] pathParts = path.split("\\.");
+                key = new StringBuilder(pathParts[pathParts.length - 1]);
+
+                // Adding the spaces before the key
+                for(int i = 0; i < pathParts.length - 1; i++)
+                    key.insert(0, "  ");
+            }
+
+            return key.toString();
+        }
+
+        /**
+         * Sets a comment above a certain key
+         *
+         * @param path        Path of the value to set comment to
+         * @param comment     Comment to set
+         */
+        public void addComment(@NotNull String path, @NotNull String comment) {
+            String key = getKeyFromPath(path);
+
+            if(this.comments.containsKey(key)) {
+                this.comments.get(key).add(comment);
+            } else {
+                List<String> listOfComments = new ArrayList<>();
+                listOfComments.add(comment);
+                this.comments.put(key, listOfComments);
+            }
+        }
+
+        /**
+         * Sets multiple comments above a certain key
+         *
+         * @param path         Path of the value to set comments to
+         * @param comments     Comment to set
+         */
+        public void addComments(@NotNull String path, @NotNull String[] comments) {
+            String key = getKeyFromPath(path);
+
+            if(this.comments.containsKey(key)) {
+                this.comments.get(key).addAll(Arrays.asList(comments));
+            } else {
+                List<String> listOfComments = new ArrayList<>(Arrays.asList(comments));
+                this.comments.put(key, listOfComments);
+            }
+        }
+
+        /**
+         * Sets the header of the config
+         *
+         * @param header   Header to set
+         */
+        public void setHeader(List<String> header) {
+            this.header.clear();
+
+            this.header.add(HEADER_SEPARATOR);
+            this.header.addAll(header);
+            this.header.add(HEADER_SEPARATOR);
+        }
+
+
+        /**
+         * Reloads the config from the saved file on the disk
+         */
+        public void reloadConfig() {
+            this.loadConfig();
+        }
+
+        /**
+         * Saves the config
+         */
+        public void saveConfig() {
+            this.saveConfig(this.getConfigAsString());
+        }
+
+        /**
+         * Returns the config as string
+         *
+         * @return   String value of the config, including comments
+         */
+        private String getConfigAsString() {
+            String configString = this.configuration.saveToString();
+            return this.applyComments(configString);
+        }
+
+        /**
+         * Saves the config:
+         *   - Gets the config string from the YamlConfiguration object
+         *   - Applies comments to the config string
+         *   - saves it to the config file
+         *
+         * @param configString string to save to the config
+         */
+        private void saveConfig(String configString) {
+            try {
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(this.configFile), StandardCharsets.UTF_8));
+                writer.write(configString);
+                writer.flush();
+                writer.close();
+            } catch(IOException exception) {
+                exception.printStackTrace();
+            }
+        }
+
+        /**
+         * Gets the config string and edits it to apply comments
+         *
+         * @param configString   Original configuration string with comments set as normal values
+         * @return               Edited configuration string with comments set as normal comments
+         */
+        private String applyComments(String configString) {
+            String[] lines = configString.split("\n"); // Getting all the lines
+
+            StringBuilder configData = new StringBuilder();
+
+            // Appending all the header comments
+            for(String comment : header)
+                configData.append(comment).append("\n");
+
+            // Looping over all lines
+            for(String line : lines) {
+
+                // If the line is a key we want to add its comments
+                if(line.contains(":")) {
+                    String key = line.split(":")[0]; // Getting only the key (removing the value)
+
+                    // Appending all the comments for this specific key
+                    List<String> listOfComments = this.comments.get(key);
+
+                    if(listOfComments != null) {
+//                        configData.append("\n");
+
+                        for(String comment : listOfComments) {
+                            if(comment.equalsIgnoreCase("\n"))
+                                continue;
+                            configData.append(comment).append("\n");
+                        }
+                    }
+                }
+
+                // Appending the line itself
+                configData.append(line).append("\n");
+            }
+
+            return configData.toString();
+        }
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
@@ -43,19 +43,20 @@ public class ImageRender extends MapRenderer {
         int scale = 4;
         int border = 2;
 
-        int size = (qr.size + border * 2) * scale;
+        int qrSize = (qr.size + border * 2) * scale;  // Size of the QR code image before resizing
 
-        BufferedImage image;
+        BufferedImage qrImage;
         boolean originalUseCache = ImageIO.getUseCache();
         ImageIO.setUseCache(false);
 
         try {
-            image = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
-            Graphics2D g = image.createGraphics();
-            g.setColor(Color.WHITE);  // Fill the entire image with white
-            g.fillRect(0, 0, size, size);
+            // Create the original QR code image
+            qrImage = new BufferedImage(qrSize, qrSize, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g = qrImage.createGraphics();
+            g.setColor(Color.WHITE);
+            g.fillRect(0, 0, qrSize, qrSize);
 
-            g.setColor(Color.BLACK);  // Draw the QR code in black
+            g.setColor(Color.BLACK);
             for (int y = 0; y < qr.size; y++) {
                 for (int x = 0; x < qr.size; x++) {
                     if (qr.getModule(x, y)) {
@@ -65,10 +66,16 @@ public class ImageRender extends MapRenderer {
             }
 
             g.dispose();
+
+            BufferedImage finalImage = new BufferedImage(128, 128, BufferedImage.TYPE_INT_RGB);
+            Graphics2D finalGraphics = finalImage.createGraphics();
+
+            finalGraphics.drawImage(qrImage, 0, 0, 128, 128, null);
+            finalGraphics.dispose();
+
+            return finalImage;
         } finally {
             ImageIO.setUseCache(originalUseCache);
         }
-
-        return image;
     }
 }

--- a/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
@@ -1,0 +1,60 @@
+package com.lielamar.auth.bukkit.utils.map;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.map.MapCanvas;
+import org.bukkit.map.MapRenderer;
+import org.bukkit.map.MapView;
+import org.jetbrains.annotations.NotNull;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.net.URL;
+
+public class ImageRender extends MapRenderer {
+
+    private final SoftReference<BufferedImage> cacheImage;
+
+    private boolean hasRendered = false;
+
+    public ImageRender(String url) throws IOException {
+        this.cacheImage = new SoftReference<>(this.getImage(url));
+    }
+
+    @Override
+    public void render(@NotNull MapView view, @NotNull MapCanvas canvas, @NotNull Player player) {
+        if(this.hasRendered) return;
+
+        view.setScale(MapView.Scale.CLOSEST);
+
+        if(this.cacheImage != null && this.cacheImage.get() != null)
+            canvas.drawImage(0, 0, this.cacheImage.get());
+        else
+            player.sendMessage(ChatColor.RED + "Attempted to render the image, but the cached image was null!");
+
+        this.hasRendered = true;
+    }
+
+    private BufferedImage getImage(String url) throws IOException {
+        boolean useCache = ImageIO.getUseCache();
+        ImageIO.setUseCache(false);
+
+        BufferedImage image = resize(new URL(url), new Dimension(128, 128));
+
+        ImageIO.setUseCache(useCache);
+        return image;
+    }
+
+    private BufferedImage resize(final URL url, final Dimension size) throws IOException {
+        final BufferedImage image = ImageIO.read(url.openStream());
+        final BufferedImage resized = new BufferedImage(size.width, size.height, BufferedImage.TYPE_INT_ARGB);
+        final Graphics2D g = resized.createGraphics();
+
+        g.drawImage(image, 0, 0, size.width, size.height, null);
+        g.dispose();
+        return resized;
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/map/ImageRender.java
@@ -1,5 +1,6 @@
 package com.lielamar.auth.bukkit.utils.map;
 
+import com.lielamar.auth.bukkit.utils.nayukifast.QrCode;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
@@ -10,27 +11,25 @@ import org.jetbrains.annotations.NotNull;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
 import java.lang.ref.SoftReference;
-import java.net.URL;
+import java.net.URI;
 
 public class ImageRender extends MapRenderer {
 
     private final SoftReference<BufferedImage> cacheImage;
-
     private boolean hasRendered = false;
 
-    public ImageRender(String url) throws IOException {
-        this.cacheImage = new SoftReference<>(this.getImage(url));
+    public ImageRender(String uri) {
+        this.cacheImage = new SoftReference<>(this.generateQrCodeImage(uri));
     }
 
     @Override
     public void render(@NotNull MapView view, @NotNull MapCanvas canvas, @NotNull Player player) {
-        if(this.hasRendered) return;
+        if (this.hasRendered) return;
 
         view.setScale(MapView.Scale.CLOSEST);
 
-        if(this.cacheImage != null && this.cacheImage.get() != null)
+        if (this.cacheImage != null && this.cacheImage.get() != null)
             canvas.drawImage(0, 0, this.cacheImage.get());
         else
             player.sendMessage(ChatColor.RED + "Attempted to render the image, but the cached image was null!");
@@ -38,23 +37,38 @@ public class ImageRender extends MapRenderer {
         this.hasRendered = true;
     }
 
-    private BufferedImage getImage(String url) throws IOException {
-        boolean useCache = ImageIO.getUseCache();
+    private BufferedImage generateQrCodeImage(String uri) {
+        QrCode qr = QrCode.encodeText(uri, QrCode.Ecc.MEDIUM);
+
+        int scale = 4;
+        int border = 2;
+
+        int size = (qr.size + border * 2) * scale;
+
+        BufferedImage image;
+        boolean originalUseCache = ImageIO.getUseCache();
         ImageIO.setUseCache(false);
 
-        BufferedImage image = resize(new URL(url), new Dimension(128, 128));
+        try {
+            image = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g = image.createGraphics();
+            g.setColor(Color.WHITE);  // Fill the entire image with white
+            g.fillRect(0, 0, size, size);
 
-        ImageIO.setUseCache(useCache);
+            g.setColor(Color.BLACK);  // Draw the QR code in black
+            for (int y = 0; y < qr.size; y++) {
+                for (int x = 0; x < qr.size; x++) {
+                    if (qr.getModule(x, y)) {
+                        g.fillRect((x + border) * scale, (y + border) * scale, scale, scale);
+                    }
+                }
+            }
+
+            g.dispose();
+        } finally {
+            ImageIO.setUseCache(originalUseCache);
+        }
+
         return image;
-    }
-
-    private BufferedImage resize(final URL url, final Dimension size) throws IOException {
-        final BufferedImage image = ImageIO.read(url.openStream());
-        final BufferedImage resized = new BufferedImage(size.width, size.height, BufferedImage.TYPE_INT_ARGB);
-        final Graphics2D g = resized.createGraphics();
-
-        g.drawImage(image, 0, 0, size.width, size.height, null);
-        g.dispose();
-        return resized;
     }
 }

--- a/src/main/java/com/lielamar/auth/bukkit/utils/map/MapUtils.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/map/MapUtils.java
@@ -1,0 +1,26 @@
+package com.lielamar.auth.bukkit.utils.map;
+
+import org.bukkit.map.MapView;
+
+public class MapUtils {
+
+    /**
+     * Returns the ID of a MapView for versions before 1.13
+     *
+     * @param view   MapView to get the ID of
+     * @return       ID of view
+     */
+    public static short getMapID(MapView view) {
+        try {
+            return (short) view.getId();
+        } catch (NoSuchMethodError e) {
+            try {
+                Class<?> MapView = Class.forName("org.bukkit.map.MapView");
+                Object mapID = MapView.getMethod("getId").invoke(view);
+                return (short) mapID;
+            } catch (Exception e1) {
+                return 1;
+            }
+        }
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/BitBuffer.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/BitBuffer.java
@@ -1,0 +1,134 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+
+// An appendable sequence of bits (0s and 1s), mainly used by QrSegment.
+final class BitBuffer {
+	
+	/*---- Fields ----*/
+	
+	int[] data;  // In each 32-bit word, bits are filled from top down.
+	
+	int bitLength;  // Always non-negative.
+	
+	
+	
+	/*---- Constructor ----*/
+	
+	// Creates an empty bit buffer.
+	public BitBuffer() {
+		data = new int[64];
+		bitLength = 0;
+	}
+	
+	
+	
+	/*---- Methods ----*/
+	
+	// Returns the bit at the given index, yielding 0 or 1.
+	public int getBit(int index) {
+		if (index < 0 || index >= bitLength)
+			throw new IndexOutOfBoundsException();
+		return (data[index >>> 5] >>> ~index) & 1;
+	}
+	
+	
+	// Returns a new array representing this buffer's bits packed into
+	// bytes in big endian. The current bit length must be a multiple of 8.
+	public byte[] getBytes() {
+		if (bitLength % 8 != 0)
+			throw new IllegalStateException("Data is not a whole number of bytes");
+		byte[] result = new byte[bitLength / 8];
+		for (int i = 0; i < result.length; i++)
+			result[i] = (byte)(data[i >>> 2] >>> (~i << 3));
+		return result;
+	}
+	
+	
+	// Appends the given number of low-order bits of the given value
+	// to this buffer. Requires 0 <= len <= 31 and 0 <= val < 2^len.
+	public void appendBits(int val, int len) {
+		if (len < 0 || len > 31 || val >>> len != 0)
+			throw new IllegalArgumentException("Value out of range");
+		if (len > Integer.MAX_VALUE - bitLength)
+			throw new IllegalStateException("Maximum length reached");
+		
+		if (bitLength + len + 1 > data.length << 5)
+			data = Arrays.copyOf(data, data.length * 2);
+		assert bitLength + len <= data.length << 5;
+		
+		int remain = 32 - (bitLength & 0x1F);
+		assert 1 <= remain && remain <= 32;
+		if (remain < len) {
+			data[bitLength >>> 5] |= val >>> (len - remain);
+			bitLength += remain;
+			assert (bitLength & 0x1F) == 0;
+			len -= remain;
+			val &= (1 << len) - 1;
+			remain = 32;
+		}
+		data[bitLength >>> 5] |= val << (remain - len);
+		bitLength += len;
+	}
+	
+	
+	// Appends to this buffer the sequence of bits represented by the given
+	// word array and given bit length. Requires 0 <= len <= 32 * vals.length.
+	public void appendBits(int[] vals, int len) {
+		Objects.requireNonNull(vals);
+		if (len == 0)
+			return;
+		if (len < 0 || len > vals.length * 32L)
+			throw new IllegalArgumentException("Value out of range");
+		int wholeWords = len / 32;
+		int tailBits = len % 32;
+		if (tailBits > 0 && vals[wholeWords] << tailBits != 0)
+			throw new IllegalArgumentException("Last word must have low bits clear");
+		if (len > Integer.MAX_VALUE - bitLength)
+			throw new IllegalStateException("Maximum length reached");
+		
+		while (bitLength + len > data.length * 32)
+			data = Arrays.copyOf(data, data.length * 2);
+		
+		int shift = bitLength % 32;
+		if (shift == 0) {
+			System.arraycopy(vals, 0, data, bitLength / 32, (len + 31) / 32);
+			bitLength += len;
+		} else {
+			for (int i = 0; i < wholeWords; i++) {
+				int word = vals[i];
+				data[bitLength >>> 5] |= word >>> shift;
+				bitLength += 32;
+				data[bitLength >>> 5] = word << (32 - shift);
+			}
+			if (tailBits > 0)
+				appendBits(vals[wholeWords] >>> (32 - tailBits), tailBits);
+		}
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/DataTooLongException.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/DataTooLongException.java
@@ -1,0 +1,57 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+
+/**
+ * Thrown when the supplied data does not fit any QR Code version. Ways to handle this exception include:
+ * <ul>
+ *   <li><p>Decrease the error correction level if it was greater than {@code Ecc.LOW}.</p></li>
+ *   <li><p>If the advanced {@code encodeSegments()} function with 6 arguments or the
+ *     {@code makeSegmentsOptimally()} function was called, then increase the maxVersion argument
+ *     if it was less than {@link QrCode#MAX_VERSION}. (This advice does not apply to the other
+ *     factory functions because they search all versions up to {@code QrCode.MAX_VERSION}.)</p></li>
+ *   <li><p>Split the text data into better or optimal segments in order to reduce the number of
+ *     bits required. (See {@link QrSegmentAdvanced#makeSegmentsOptimally(String,QrCode.Ecc,int,int)
+ *     QrSegmentAdvanced.makeSegmentsOptimally()}.)</p></li>
+ *   <li><p>Change the text or binary data to be shorter.</p></li>
+ *   <li><p>Change the text to fit the character set of a particular segment mode (e.g. alphanumeric).</p></li>
+ *   <li><p>Propagate the error upward to the caller/user.</p></li>
+ * </ul>
+ * @see QrCode#encodeText(String, QrCode.Ecc)
+ * @see QrCode#encodeBinary(byte[], QrCode.Ecc)
+ * @see QrCode#encodeSegments(java.util.List, QrCode.Ecc)
+ * @see QrCode#encodeSegments(java.util.List, QrCode.Ecc, int, int, int, boolean)
+ * @see QrSegmentAdvanced#makeSegmentsOptimally(String, QrCode.Ecc, int, int)
+ */
+public class DataTooLongException extends IllegalArgumentException {
+	
+	public DataTooLongException() {}
+	
+	
+	public DataTooLongException(String msg) {
+		super(msg);
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/Memoizer.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/Memoizer.java
@@ -1,0 +1,95 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import java.lang.ref.SoftReference;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+
+// A thread-safe cache based on soft references.
+final class Memoizer<T,R> {
+	
+	private final Function<T,R> function;
+	Map<T,SoftReference<R>> cache = new ConcurrentHashMap<>();
+	private Set<T> pending = new HashSet<>();
+	
+	
+	// Creates a memoizer based on the given function that takes one input to compute an output.
+	public Memoizer(Function<T,R> func) {
+		function = func;
+	}
+	
+	
+	// Computes function.apply(arg) or returns a cached copy of a previous call.
+	public R get(T arg) {
+		// Non-blocking fast path
+		{
+			SoftReference<R> ref = cache.get(arg);
+			if (ref != null) {
+				R result = ref.get();
+				if (result != null)
+					return result;
+			}
+		}
+		
+		// Sequential slow path
+		while (true) {
+			synchronized(this) {
+				SoftReference<R> ref = cache.get(arg);
+				if (ref != null) {
+					R result = ref.get();
+					if (result != null)
+						return result;
+					cache.remove(arg);
+				}
+				assert !cache.containsKey(arg);
+				
+				if (pending.add(arg))
+					break;
+				
+				try {
+					this.wait();
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
+		
+		try {
+			R result = function.apply(arg);
+			cache.put(arg, new SoftReference<>(result));
+			return result;
+		} finally {
+			synchronized(this) {
+				pending.remove(arg);
+				this.notifyAll();
+			}
+		}
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrCode.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrCode.java
@@ -1,0 +1,595 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * A QR Code symbol, which is a type of two-dimension barcode.
+ * Invented by Denso Wave and described in the ISO/IEC 18004 standard.
+ * <p>Instances of this class represent an immutable square grid of dark and light cells.
+ * The class provides static factory functions to create a QR Code from text or binary data.
+ * The class covers the QR Code Model 2 specification, supporting all versions (sizes)
+ * from 1 to 40, all 4 error correction levels, and 4 character encoding modes.</p>
+ * <p>Ways to create a QR Code object:</p>
+ * <ul>
+ *   <li><p>High level: Take the payload data and call {@link QrCode#encodeText(String,Ecc)}
+ *     or {@link QrCode#encodeBinary(byte[],Ecc)}.</p></li>
+ *   <li><p>Mid level: Custom-make the list of {@link QrSegment segments}
+ *     and call {@link QrCode#encodeSegments(List,Ecc)} or
+ *     {@link QrCode#encodeSegments(List,Ecc,int,int,int,boolean)}</p></li>
+ *   <li><p>Low level: Custom-make the array of data codeword bytes (including segment headers and
+ *     final padding, excluding error correction codewords), supply the appropriate version number,
+ *     and call the {@link QrCode#QrCode(int,Ecc,byte[],int) constructor}.</p></li>
+ * </ul>
+ * <p>(Note that all ways require supplying the desired error correction level.)</p>
+ * @see QrSegment
+ */
+public final class QrCode {
+	
+	/*---- Static factory functions (high level) ----*/
+	
+	/**
+	 * Returns a QR Code representing the specified Unicode text string at the specified error correction level.
+	 * As a conservative upper bound, this function is guaranteed to succeed for strings that have 738 or fewer
+	 * Unicode code points (not UTF-16 code units) if the low error correction level is used. The smallest possible
+	 * QR Code version is automatically chosen for the output. The ECC level of the result may be higher than the
+	 * ecl argument if it can be done without increasing the version.
+	 * @param text the text to be encoded (not {@code null}), which can be any Unicode string
+	 * @param ecl the error correction level to use (not {@code null}) (boostable)
+	 * @return a QR Code (not {@code null}) representing the text
+	 * @throws NullPointerException if the text or error correction level is {@code null}
+	 * @throws DataTooLongException if the text fails to fit in the
+	 * largest version QR Code at the ECL, which means it is too long
+	 */
+	public static QrCode encodeText(String text, Ecc ecl) {
+		Objects.requireNonNull(text);
+		Objects.requireNonNull(ecl);
+		List<QrSegment> segs = QrSegment.makeSegments(text);
+		return encodeSegments(segs, ecl);
+	}
+	
+	
+	/**
+	 * Returns a QR Code representing the specified binary data at the specified error correction level.
+	 * This function always encodes using the binary segment mode, not any text mode. The maximum number of
+	 * bytes allowed is 2953. The smallest possible QR Code version is automatically chosen for the output.
+	 * The ECC level of the result may be higher than the ecl argument if it can be done without increasing the version.
+	 * @param data the binary data to encode (not {@code null})
+	 * @param ecl the error correction level to use (not {@code null}) (boostable)
+	 * @return a QR Code (not {@code null}) representing the data
+	 * @throws NullPointerException if the data or error correction level is {@code null}
+	 * @throws DataTooLongException if the data fails to fit in the
+	 * largest version QR Code at the ECL, which means it is too long
+	 */
+	public static QrCode encodeBinary(byte[] data, Ecc ecl) {
+		Objects.requireNonNull(data);
+		Objects.requireNonNull(ecl);
+		QrSegment seg = QrSegment.makeBytes(data);
+		return encodeSegments(Arrays.asList(seg), ecl);
+	}
+	
+	
+	/*---- Static factory functions (mid level) ----*/
+	
+	/**
+	 * Returns a QR Code representing the specified segments at the specified error correction
+	 * level. The smallest possible QR Code version is automatically chosen for the output. The ECC level
+	 * of the result may be higher than the ecl argument if it can be done without increasing the version.
+	 * <p>This function allows the user to create a custom sequence of segments that switches
+	 * between modes (such as alphanumeric and byte) to encode text in less space.
+	 * This is a mid-level API; the high-level API is {@link #encodeText(String,Ecc)}
+	 * and {@link #encodeBinary(byte[],Ecc)}.</p>
+	 * @param segs the segments to encode
+	 * @param ecl the error correction level to use (not {@code null}) (boostable)
+	 * @return a QR Code (not {@code null}) representing the segments
+	 * @throws NullPointerException if the list of segments, any segment, or the error correction level is {@code null}
+	 * @throws DataTooLongException if the segments fail to fit in the
+	 * largest version QR Code at the ECL, which means they are too long
+	 */
+	public static QrCode encodeSegments(List<QrSegment> segs, Ecc ecl) {
+		return encodeSegments(segs, ecl, MIN_VERSION, MAX_VERSION, -1, true);
+	}
+	
+	
+	/**
+	 * Returns a QR Code representing the specified segments with the specified encoding parameters.
+	 * The smallest possible QR Code version within the specified range is automatically
+	 * chosen for the output. Iff boostEcl is {@code true}, then the ECC level of the
+	 * result may be higher than the ecl argument if it can be done without increasing
+	 * the version. The mask number is either between 0 to 7 (inclusive) to force that
+	 * mask, or &#x2212;1 to automatically choose an appropriate mask (which may be slow).
+	 * <p>This function allows the user to create a custom sequence of segments that switches
+	 * between modes (such as alphanumeric and byte) to encode text in less space.
+	 * This is a mid-level API; the high-level API is {@link #encodeText(String,Ecc)}
+	 * and {@link #encodeBinary(byte[],Ecc)}.</p>
+	 * @param segs the segments to encode
+	 * @param ecl the error correction level to use (not {@code null}) (boostable)
+	 * @param minVersion the minimum allowed version of the QR Code (at least 1)
+	 * @param maxVersion the maximum allowed version of the QR Code (at most 40)
+	 * @param mask the mask number to use (between 0 and 7 (inclusive)), or &#x2212;1 for automatic mask
+	 * @param boostEcl increases the ECC level as long as it doesn't increase the version number
+	 * @return a QR Code (not {@code null}) representing the segments
+	 * @throws NullPointerException if the list of segments, any segment, or the error correction level is {@code null}
+	 * @throws IllegalArgumentException if 1 &#x2264; minVersion &#x2264; maxVersion &#x2264; 40
+	 * or &#x2212;1 &#x2264; mask &#x2264; 7 is violated
+	 * @throws DataTooLongException if the segments fail to fit in
+	 * the maxVersion QR Code at the ECL, which means they are too long
+	 */
+	public static QrCode encodeSegments(List<QrSegment> segs, Ecc ecl, int minVersion, int maxVersion, int mask, boolean boostEcl) {
+		Objects.requireNonNull(segs);
+		Objects.requireNonNull(ecl);
+		if (!(MIN_VERSION <= minVersion && minVersion <= maxVersion && maxVersion <= MAX_VERSION) || mask < -1 || mask > 7)
+			throw new IllegalArgumentException("Invalid value");
+		
+		// Find the minimal version number to use
+		int version, dataUsedBits;
+		for (version = minVersion; ; version++) {
+			int dataCapacityBits = getNumDataCodewords(version, ecl) * 8;  // Number of data bits available
+			dataUsedBits = QrSegment.getTotalBits(segs, version);
+			if (dataUsedBits != -1 && dataUsedBits <= dataCapacityBits)
+				break;  // This version number is found to be suitable
+			if (version >= maxVersion) {  // All versions in the range could not fit the given data
+				String msg = "Segment too long";
+				if (dataUsedBits != -1)
+					msg = String.format("Data length = %d bits, Max capacity = %d bits", dataUsedBits, dataCapacityBits);
+				throw new DataTooLongException(msg);
+			}
+		}
+		assert dataUsedBits != -1;
+		
+		// Increase the error correction level while the data still fits in the current version number
+		for (Ecc newEcl : Ecc.values()) {  // From low to high
+			if (boostEcl && dataUsedBits <= getNumDataCodewords(version, newEcl) * 8)
+				ecl = newEcl;
+		}
+		
+		// Concatenate all segments to create the data bit string
+		BitBuffer bb = new BitBuffer();
+		for (QrSegment seg : segs) {
+			bb.appendBits(seg.mode.modeBits, 4);
+			bb.appendBits(seg.numChars, seg.mode.numCharCountBits(version));
+			bb.appendBits(seg.data, seg.bitLength);
+		}
+		assert bb.bitLength == dataUsedBits;
+		
+		// Add terminator and pad up to a byte if applicable
+		int dataCapacityBits = getNumDataCodewords(version, ecl) * 8;
+		assert bb.bitLength <= dataCapacityBits;
+		bb.appendBits(0, Math.min(4, dataCapacityBits - bb.bitLength));
+		bb.appendBits(0, (8 - bb.bitLength % 8) % 8);
+		assert bb.bitLength % 8 == 0;
+		
+		// Pad with alternating bytes until data capacity is reached
+		for (int padByte = 0xEC; bb.bitLength < dataCapacityBits; padByte ^= 0xEC ^ 0x11)
+			bb.appendBits(padByte, 8);
+		
+		// Create the QR Code object
+		return new QrCode(version, ecl, bb.getBytes(), mask);
+	}
+	
+	
+	
+	/*---- Instance fields ----*/
+	
+	// Public immutable scalar parameters:
+	
+	/** The version number of this QR Code, which is between 1 and 40 (inclusive).
+	 * This determines the size of this barcode. */
+	public final int version;
+	
+	/** The width and height of this QR Code, measured in modules, between
+	 * 21 and 177 (inclusive). This is equal to version &#xD7; 4 + 17. */
+	public final int size;
+	
+	/** The error correction level used in this QR Code, which is not {@code null}. */
+	public final Ecc errorCorrectionLevel;
+	
+	/** The index of the mask pattern used in this QR Code, which is between 0 and 7 (inclusive).
+	 * <p>Even if a QR Code is created with automatic masking requested (mask =
+	 * &#x2212;1), the resulting object still has a mask value between 0 and 7. */
+	public final int mask;
+	
+	// Private grid of modules of this QR Code, packed tightly into bits.
+	// Immutable after constructor finishes. Accessed through getModule().
+	private final int[] modules;
+	
+	
+	
+	/*---- Constructor (low level) ----*/
+	
+	/**
+	 * Constructs a QR Code with the specified version number,
+	 * error correction level, data codeword bytes, and mask number.
+	 * <p>This is a low-level API that most users should not use directly. A mid-level
+	 * API is the {@link #encodeSegments(List,Ecc,int,int,int,boolean)} function.</p>
+	 * @param ver the version number to use, which must be in the range 1 to 40 (inclusive)
+	 * @param ecl the error correction level to use
+	 * @param dataCodewords the bytes representing segments to encode (without ECC)
+	 * @param msk the mask pattern to use, which is either &#x2212;1 for automatic choice or from 0 to 7 for fixed choice
+	 * @throws NullPointerException if the byte array or error correction level is {@code null}
+	 * @throws IllegalArgumentException if the version or mask value is out of range,
+	 * or if the data is the wrong length for the specified version and error correction level
+	 */
+	public QrCode(int ver, Ecc ecl, byte[] dataCodewords, int msk) {
+		// Check arguments and initialize fields
+		if (ver < MIN_VERSION || ver > MAX_VERSION)
+			throw new IllegalArgumentException("Version value out of range");
+		if (msk < -1 || msk > 7)
+			throw new IllegalArgumentException("Mask value out of range");
+		version = ver;
+		size = ver * 4 + 17;
+		errorCorrectionLevel = Objects.requireNonNull(ecl);
+		Objects.requireNonNull(dataCodewords);
+		
+		QrTemplate tpl = QrTemplate.MEMOIZER.get(ver);
+		modules = tpl.template.clone();
+		
+		// Compute ECC, draw modules, do masking
+		byte[] allCodewords = addEccAndInterleave(dataCodewords);
+		drawCodewords(tpl.dataOutputBitIndexes, allCodewords);
+		mask = handleConstructorMasking(tpl.masks, msk);
+	}
+	
+	
+	
+	/*---- Public instance methods ----*/
+	
+	/**
+	 * Returns the color of the module (pixel) at the specified coordinates, which is {@code false}
+	 * for light or {@code true} for dark. The top left corner has the coordinates (x=0, y=0).
+	 * If the specified coordinates are out of bounds, then {@code false} (light) is returned.
+	 * @param x the x coordinate, where 0 is the left edge and size&#x2212;1 is the right edge
+	 * @param y the y coordinate, where 0 is the top edge and size&#x2212;1 is the bottom edge
+	 * @return {@code true} if the coordinates are in bounds and the module
+	 * at that location is dark, or {@code false} (light) otherwise
+	 */
+	public boolean getModule(int x, int y) {
+		if (0 <= x && x < size && 0 <= y && y < size) {
+			int i = y * size + x;
+			return getBit(modules[i >>> 5], i) != 0;
+		} else
+			return false;
+	}
+	
+	
+	
+	/*---- Private helper methods for constructor: Drawing function modules ----*/
+	
+	// Draws two copies of the format bits (with its own error correction code)
+	// based on the given mask and this object's error correction level field.
+	private void drawFormatBits(int msk) {
+		// Calculate error correction code and pack bits
+		int data = errorCorrectionLevel.formatBits << 3 | msk;  // errCorrLvl is uint2, mask is uint3
+		int rem = data;
+		for (int i = 0; i < 10; i++)
+			rem = (rem << 1) ^ ((rem >>> 9) * 0x537);
+		int bits = (data << 10 | rem) ^ 0x5412;  // uint15
+		assert bits >>> 15 == 0;
+		
+		// Draw first copy
+		for (int i = 0; i <= 5; i++)
+			setModule(8, i, getBit(bits, i));
+		setModule(8, 7, getBit(bits, 6));
+		setModule(8, 8, getBit(bits, 7));
+		setModule(7, 8, getBit(bits, 8));
+		for (int i = 9; i < 15; i++)
+			setModule(14 - i, 8, getBit(bits, i));
+		
+		// Draw second copy
+		for (int i = 0; i < 8; i++)
+			setModule(size - 1 - i, 8, getBit(bits, i));
+		for (int i = 8; i < 15; i++)
+			setModule(8, size - 15 + i, getBit(bits, i));
+		setModule(8, size - 8, 1);  // Always dark
+	}
+	
+	
+	// Sets the module at the given coordinates to the given color.
+	// Only used by the constructor. Coordinates must be in bounds.
+	private void setModule(int x, int y, int dark) {
+		assert 0 <= x && x < size;
+		assert 0 <= y && y < size;
+		assert dark == 0 || dark == 1;
+		int i = y * size + x;
+		modules[i >>> 5] &= ~(1 << i);
+		modules[i >>> 5] |= dark << i;
+	}
+	
+	
+	/*---- Private helper methods for constructor: Codewords and masking ----*/
+	
+	// Returns a new byte string representing the given data with the appropriate error correction
+	// codewords appended to it, based on this object's version and error correction level.
+	private byte[] addEccAndInterleave(byte[] data) {
+		Objects.requireNonNull(data);
+		if (data.length != getNumDataCodewords(version, errorCorrectionLevel))
+			throw new IllegalArgumentException();
+		
+		// Calculate parameter numbers
+		int numBlocks = NUM_ERROR_CORRECTION_BLOCKS[errorCorrectionLevel.ordinal()][version];
+		int blockEccLen = ECC_CODEWORDS_PER_BLOCK  [errorCorrectionLevel.ordinal()][version];
+		int rawCodewords = QrTemplate.getNumRawDataModules(version) / 8;
+		int numShortBlocks = numBlocks - rawCodewords % numBlocks;
+		int shortBlockDataLen = rawCodewords / numBlocks - blockEccLen;
+		
+		// Split data into blocks, calculate ECC, and interleave
+		// (not concatenate) the bytes into a single sequence
+		byte[] result = new byte[rawCodewords];
+		ReedSolomonGenerator rs = ReedSolomonGenerator.MEMOIZER.get(blockEccLen);
+		byte[] ecc = new byte[blockEccLen];  // Temporary storage per iteration
+		for (int i = 0, k = 0; i < numBlocks; i++) {
+			int datLen = shortBlockDataLen + (i < numShortBlocks ? 0 : 1);
+			rs.getRemainder(data, k, datLen, ecc);
+			for (int j = 0, l = i; j < datLen; j++, k++, l += numBlocks) {  // Copy data
+				if (j == shortBlockDataLen)
+					l -= numShortBlocks;
+				result[l] = data[k];
+			}
+			for (int j = 0, l = data.length + i; j < blockEccLen; j++, l += numBlocks)  // Copy ECC
+				result[l] = ecc[j];
+		}
+		return result;
+	}
+	
+	
+	// Draws the given sequence of 8-bit codewords (data and error correction)
+	// onto the entire data area of this QR Code, based on the given bit indexes.
+	private void drawCodewords(int[] dataOutputBitIndexes, byte[] allCodewords) {
+		Objects.requireNonNull(dataOutputBitIndexes);
+		Objects.requireNonNull(allCodewords);
+		if (allCodewords.length * 8 != dataOutputBitIndexes.length)
+			throw new IllegalArgumentException();
+		for (int i = 0; i < dataOutputBitIndexes.length; i++) {
+			int j = dataOutputBitIndexes[i];
+			int bit = getBit(allCodewords[i >>> 3], ~i & 7);
+			modules[j >>> 5] |= bit << j;
+		}
+	}
+	
+	
+	// XORs the codeword modules in this QR Code with the given mask pattern.
+	// The function modules must be marked and the codeword bits must be drawn
+	// before masking. Due to the arithmetic of XOR, calling applyMask() with
+	// the same mask value a second time will undo the mask. A final well-formed
+	// QR Code needs exactly one (not zero, two, etc.) mask applied.
+	private void applyMask(int[] msk) {
+		if (msk.length != modules.length)
+			throw new IllegalArgumentException();
+		for (int i = 0; i < msk.length; i++)
+			modules[i] ^= msk[i];
+	}
+	
+	
+	// A messy helper function for the constructor. This QR Code must be in an unmasked state when this
+	// method is called. The 'mask' argument is the requested mask, which is -1 for auto or 0 to 7 for fixed.
+	// This method applies and returns the actual mask chosen, from 0 to 7.
+	private int handleConstructorMasking(int[][] masks, int msk) {
+		if (msk == -1) {  // Automatically choose best mask
+			int minPenalty = Integer.MAX_VALUE;
+			for (int i = 0; i < 8; i++) {
+				applyMask(masks[i]);
+				drawFormatBits(i);
+				int penalty = getPenaltyScore();
+				if (penalty < minPenalty) {
+					msk = i;
+					minPenalty = penalty;
+				}
+				applyMask(masks[i]);  // Undoes the mask due to XOR
+			}
+		}
+		assert 0 <= msk && msk <= 7;
+		applyMask(masks[msk]);  // Apply the final choice of mask
+		drawFormatBits(msk);  // Overwrite old format bits
+		return msk;  // The caller shall assign this value to the final-declared field
+	}
+	
+	
+	// Calculates and returns the penalty score based on state of this QR Code's current modules.
+	// This is used by the automatic mask choice algorithm to find the mask pattern that yields the lowest score.
+	private int getPenaltyScore() {
+		int result = 0;
+		int dark = 0;
+		int[] runHistory = new int[7];
+		
+		// Iterate over adjacent pairs of rows
+		for (int index = 0, downIndex = size, end = size * size; index < end; ) {
+			int runColor = 0;
+			int runX = 0;
+			Arrays.fill(runHistory, 0);
+			int curRow = 0;
+			int nextRow = 0;
+			for (int x = 0; x < size; x++, index++, downIndex++) {
+				int c = getBit(modules[index >>> 5], index);
+				if (c == runColor) {
+					runX++;
+					if (runX == 5)
+						result += PENALTY_N1;
+					else if (runX > 5)
+						result++;
+				} else {
+					finderPenaltyAddHistory(runX, runHistory);
+					if (runColor == 0)
+						result += finderPenaltyCountPatterns(runHistory) * PENALTY_N3;
+					runColor = c;
+					runX = 1;
+				}
+				dark += c;
+				if (downIndex < end) {
+					curRow = ((curRow << 1) | c) & 3;
+					nextRow = ((nextRow << 1) | getBit(modules[downIndex >>> 5], downIndex)) & 3;
+					// 2*2 blocks of modules having same color
+					if (x >= 1 && (curRow == 0 || curRow == 3) && curRow == nextRow)
+						result += PENALTY_N2;
+				}
+			}
+			result += finderPenaltyTerminateAndCount(runColor, runX, runHistory) * PENALTY_N3;
+		}
+		
+		// Iterate over single columns
+		for (int x = 0; x < size; x++) {
+			int runColor = 0;
+			int runY = 0;
+			Arrays.fill(runHistory, 0);
+			for (int y = 0, index = x; y < size; y++, index += size) {
+				int c = getBit(modules[index >>> 5], index);
+				if (c == runColor) {
+					runY++;
+					if (runY == 5)
+						result += PENALTY_N1;
+					else if (runY > 5)
+						result++;
+				} else {
+					finderPenaltyAddHistory(runY, runHistory);
+					if (runColor == 0)
+						result += finderPenaltyCountPatterns(runHistory) * PENALTY_N3;
+					runColor = c;
+					runY = 1;
+				}
+			}
+			result += finderPenaltyTerminateAndCount(runColor, runY, runHistory) * PENALTY_N3;
+		}
+		
+		// Balance of dark and light modules
+		int total = size * size;  // Note that size is odd, so dark/total != 1/2
+		// Compute the smallest integer k >= 0 such that (45-5k)% <= dark/total <= (55+5k)%
+		int k = (Math.abs(dark * 20 - total * 10) + total - 1) / total - 1;
+		result += k * PENALTY_N4;
+		return result;
+	}
+	
+	
+	
+	/*---- Private helper functions ----*/
+	
+	// Returns the number of 8-bit data (i.e. not error correction) codewords contained in any
+	// QR Code of the given version number and error correction level, with remainder bits discarded.
+	// This stateless pure function could be implemented as a (40*4)-cell lookup table.
+	static int getNumDataCodewords(int ver, Ecc ecl) {
+		return QrTemplate.getNumRawDataModules(ver) / 8
+			- ECC_CODEWORDS_PER_BLOCK    [ecl.ordinal()][ver]
+			* NUM_ERROR_CORRECTION_BLOCKS[ecl.ordinal()][ver];
+	}
+	
+	
+	// Can only be called immediately after a light run is added, and
+	// returns either 0, 1, or 2. A helper function for getPenaltyScore().
+	private int finderPenaltyCountPatterns(int[] runHistory) {
+		int n = runHistory[1];
+		assert n <= size * 3;
+		boolean core = n > 0 && runHistory[2] == n && runHistory[3] == n * 3 && runHistory[4] == n && runHistory[5] == n;
+		return (core && runHistory[0] >= n * 4 && runHistory[6] >= n ? 1 : 0)
+		     + (core && runHistory[6] >= n * 4 && runHistory[0] >= n ? 1 : 0);
+	}
+	
+	
+	// Must be called at the end of a line (row or column) of modules. A helper function for getPenaltyScore().
+	private int finderPenaltyTerminateAndCount(int currentRunColor, int currentRunLength, int[] runHistory) {
+		if (currentRunColor == 1) {  // Terminate dark run
+			finderPenaltyAddHistory(currentRunLength, runHistory);
+			currentRunLength = 0;
+		}
+		currentRunLength += size;  // Add light border to final run
+		finderPenaltyAddHistory(currentRunLength, runHistory);
+		return finderPenaltyCountPatterns(runHistory);
+	}
+	
+	
+	// Pushes the given value to the front and drops the last value. A helper function for getPenaltyScore().
+	private void finderPenaltyAddHistory(int currentRunLength, int[] runHistory) {
+		if (runHistory[0] == 0)
+			currentRunLength += size;  // Add light border to initial run
+		System.arraycopy(runHistory, 0, runHistory, 1, runHistory.length - 1);
+		runHistory[0] = currentRunLength;
+	}
+	
+	
+	// Returns 0 or 1 based on the (i mod 32)'th bit of x.
+	static int getBit(int x, int i) {
+		return (x >>> i) & 1;
+	}
+	
+	
+	/*---- Constants and tables ----*/
+	
+	/** The minimum version number  (1) supported in the QR Code Model 2 standard. */
+	public static final int MIN_VERSION =  1;
+	
+	/** The maximum version number (40) supported in the QR Code Model 2 standard. */
+	public static final int MAX_VERSION = 40;
+	
+	
+	// For use in getPenaltyScore(), when evaluating which mask is best.
+	private static final int PENALTY_N1 =  3;
+	private static final int PENALTY_N2 =  3;
+	private static final int PENALTY_N3 = 40;
+	private static final int PENALTY_N4 = 10;
+	
+	
+	private static final byte[][] ECC_CODEWORDS_PER_BLOCK = {
+		// Version: (note that index 0 is for padding, and is set to an illegal value)
+		//0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40    Error correction level
+		{-1,  7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30},  // Low
+		{-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28},  // Medium
+		{-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30},  // Quartile
+		{-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30},  // High
+	};
+	
+	private static final byte[][] NUM_ERROR_CORRECTION_BLOCKS = {
+		// Version: (note that index 0 is for padding, and is set to an illegal value)
+		//0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40    Error correction level
+		{-1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4,  4,  4,  4,  4,  6,  6,  6,  6,  7,  8,  8,  9,  9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25},  // Low
+		{-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5,  5,  8,  9,  9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49},  // Medium
+		{-1, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8,  8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68},  // Quartile
+		{-1, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81},  // High
+	};
+	
+	
+	
+	/*---- Public helper enumeration ----*/
+	
+	/**
+	 * The error correction level in a QR Code symbol.
+	 */
+	public enum Ecc {
+		// Must be declared in ascending order of error protection
+		// so that the implicit ordinal() and values() work properly
+		/** The QR Code can tolerate about  7% erroneous codewords. */ LOW(1),
+		/** The QR Code can tolerate about 15% erroneous codewords. */ MEDIUM(0),
+		/** The QR Code can tolerate about 25% erroneous codewords. */ QUARTILE(3),
+		/** The QR Code can tolerate about 30% erroneous codewords. */ HIGH(2);
+		
+		// In the range 0 to 3 (unsigned 2-bit integer).
+		final int formatBits;
+		
+		// Constructor.
+		private Ecc(int fb) {
+			formatBits = fb;
+		}
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrSegment.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrSegment.java
@@ -1,0 +1,338 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * A segment of character/binary/control data in a QR Code symbol.
+ * Instances of this class are immutable.
+ * <p>The mid-level way to create a segment is to take the payload data and call a
+ * static factory function such as {@link QrSegment#makeNumeric(String)}. The low-level
+ * way to create a segment is to custom-make the bit buffer and call the {@link
+ * QrSegment#QrSegment(Mode,int,int[],int) constructor} with appropriate values.</p>
+ * <p>This segment class imposes no length restrictions, but QR Codes have restrictions.
+ * Even in the most favorable conditions, a QR Code can only hold 7089 characters of data.
+ * Any segment longer than this is meaningless for the purpose of generating QR Codes.
+ * This class can represent kanji mode segments, but provides no help in encoding them
+ * - see {@link QrSegmentAdvanced} for full kanji support.</p>
+ */
+public final class QrSegment {
+	
+	/*---- Static factory functions (mid level) ----*/
+	
+	/**
+	 * Returns a segment representing the specified binary data
+	 * encoded in byte mode. All input byte arrays are acceptable.
+	 * <p>Any text string can be converted to UTF-8 bytes ({@code
+	 * s.getBytes(StandardCharsets.UTF_8)}) and encoded as a byte mode segment.</p>
+	 * @param data the binary data (not {@code null})
+	 * @return a segment (not {@code null}) containing the data
+	 * @throws NullPointerException if the array is {@code null}
+	 */
+	public static QrSegment makeBytes(byte[] data) {
+		Objects.requireNonNull(data);
+		if (data.length * 8L > Integer.MAX_VALUE)
+			throw new IllegalArgumentException("Data too long");
+		int[] bits = new int[(data.length + 3) / 4];
+		for (int i = 0; i < data.length; i++)
+			bits[i >>> 2] |= (data[i] & 0xFF) << (~i << 3);
+		return new QrSegment(Mode.BYTE, data.length, bits, data.length * 8);
+	}
+	
+	
+	/**
+	 * Returns a segment representing the specified string of decimal digits encoded in numeric mode.
+	 * @param digits the text (not {@code null}), with only digits from 0 to 9 allowed
+	 * @return a segment (not {@code null}) containing the text
+	 * @throws NullPointerException if the string is {@code null}
+	 * @throws IllegalArgumentException if the string contains non-digit characters
+	 */
+	public static QrSegment makeNumeric(String digits) {
+		Objects.requireNonNull(digits);
+		BitBuffer bb = new BitBuffer();
+		int accumData = 0;
+		int accumCount = 0;
+		for (int i = 0; i < digits.length(); i++) {
+			char c = digits.charAt(i);
+			if (c < '0' || c > '9')
+				throw new IllegalArgumentException("String contains non-numeric characters");
+			accumData = accumData * 10 + (c - '0');
+			accumCount++;
+			if (accumCount == 3) {
+				bb.appendBits(accumData, 10);
+				accumData = 0;
+				accumCount = 0;
+			}
+		}
+		if (accumCount > 0)  // 1 or 2 digits remaining
+			bb.appendBits(accumData, accumCount * 3 + 1);
+		return new QrSegment(Mode.NUMERIC, digits.length(), bb.data, bb.bitLength);
+	}
+	
+	
+	/**
+	 * Returns a segment representing the specified text string encoded in alphanumeric mode.
+	 * The characters allowed are: 0 to 9, A to Z (uppercase only), space,
+	 * dollar, percent, asterisk, plus, hyphen, period, slash, colon.
+	 * @param text the text (not {@code null}), with only certain characters allowed
+	 * @return a segment (not {@code null}) containing the text
+	 * @throws NullPointerException if the string is {@code null}
+	 * @throws IllegalArgumentException if the string contains non-encodable characters
+	 */
+	public static QrSegment makeAlphanumeric(String text) {
+		Objects.requireNonNull(text);
+		BitBuffer bb = new BitBuffer();
+		int accumData = 0;
+		int accumCount = 0;
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (c >= ALPHANUMERIC_MAP.length || ALPHANUMERIC_MAP[c] == -1)
+				throw new IllegalArgumentException("String contains unencodable characters in alphanumeric mode");
+			accumData = accumData * 45 + ALPHANUMERIC_MAP[c];
+			accumCount++;
+			if (accumCount == 2) {
+				bb.appendBits(accumData, 11);
+				accumData = 0;
+				accumCount = 0;
+			}
+		}
+		if (accumCount > 0)  // 1 character remaining
+			bb.appendBits(accumData, 6);
+		return new QrSegment(Mode.ALPHANUMERIC, text.length(), bb.data, bb.bitLength);
+	}
+	
+	
+	/**
+	 * Returns a list of zero or more segments to represent the specified Unicode text string.
+	 * The result may use various segment modes and switch modes to optimize the length of the bit stream.
+	 * @param text the text to be encoded, which can be any Unicode string
+	 * @return a new mutable list (not {@code null}) of segments (not {@code null}) containing the text
+	 * @throws NullPointerException if the text is {@code null}
+	 */
+	public static List<QrSegment> makeSegments(String text) {
+		Objects.requireNonNull(text);
+		
+		// Select the most efficient segment encoding automatically
+		List<QrSegment> result = new ArrayList<>();
+		if (text.equals(""));  // Leave result empty
+		else if (isNumeric(text))
+			result.add(makeNumeric(text));
+		else if (isAlphanumeric(text))
+			result.add(makeAlphanumeric(text));
+		else
+			result.add(makeBytes(text.getBytes(StandardCharsets.UTF_8)));
+		return result;
+	}
+	
+	
+	/**
+	 * Returns a segment representing an Extended Channel Interpretation
+	 * (ECI) designator with the specified assignment value.
+	 * @param assignVal the ECI assignment number (see the AIM ECI specification)
+	 * @return a segment (not {@code null}) containing the data
+	 * @throws IllegalArgumentException if the value is outside the range [0, 10<sup>6</sup>)
+	 */
+	public static QrSegment makeEci(int assignVal) {
+		BitBuffer bb = new BitBuffer();
+		if (assignVal < 0)
+			throw new IllegalArgumentException("ECI assignment value out of range");
+		else if (assignVal < (1 << 7))
+			bb.appendBits(assignVal, 8);
+		else if (assignVal < (1 << 14)) {
+			bb.appendBits(2, 2);
+			bb.appendBits(assignVal, 14);
+		} else if (assignVal < 1_000_000) {
+			bb.appendBits(6, 3);
+			bb.appendBits(assignVal, 21);
+		} else
+			throw new IllegalArgumentException("ECI assignment value out of range");
+		return new QrSegment(Mode.ECI, 0, bb.data, bb.bitLength);
+	}
+	
+	
+	/**
+	 * Tests whether the specified string can be encoded as a segment in numeric mode.
+	 * A string is encodable iff each character is in the range 0 to 9.
+	 * @param text the string to test for encodability (not {@code null})
+	 * @return {@code true} iff each character is in the range 0 to 9.
+	 * @throws NullPointerException if the string is {@code null}
+	 * @see #makeNumeric(String)
+	 */
+	public static boolean isNumeric(String text) {
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (c < '0' || c > '9')
+				return false;
+		}
+		return true;
+	}
+	
+	
+	/**
+	 * Tests whether the specified string can be encoded as a segment in alphanumeric mode.
+	 * A string is encodable iff each character is in the following set: 0 to 9, A to Z
+	 * (uppercase only), space, dollar, percent, asterisk, plus, hyphen, period, slash, colon.
+	 * @param text the string to test for encodability (not {@code null})
+	 * @return {@code true} iff each character is in the alphanumeric mode character set
+	 * @throws NullPointerException if the string is {@code null}
+	 * @see #makeAlphanumeric(String)
+	 */
+	public static boolean isAlphanumeric(String text) {
+		for (int i = 0; i < text.length(); i++) {
+			char c = text.charAt(i);
+			if (c >= ALPHANUMERIC_MAP.length || ALPHANUMERIC_MAP[c] == -1)
+				return false;
+		}
+		return true;
+	}
+	
+	
+	
+	/*---- Instance fields ----*/
+	
+	/** The mode indicator of this segment. Not {@code null}. */
+	public final Mode mode;
+	
+	/** The length of this segment's unencoded data. Measured in characters for
+	 * numeric/alphanumeric/kanji mode, bytes for byte mode, and 0 for ECI mode.
+	 * Always zero or positive. Not the same as the data's bit length. */
+	public final int numChars;
+	
+	// The data bits of this segment. Not null.
+	final int[] data;
+	
+	// Requires 0 <= bitLength <= data.length * 32.
+	final int bitLength;
+	
+	
+	/*---- Constructor (low level) ----*/
+	
+	/**
+	 * Constructs a QR Code segment with the specified attributes and data.
+	 * The character count (numCh) must agree with the mode and the bit buffer length,
+	 * but the constraint isn't checked. The specified bit buffer is cloned and stored.
+	 * @param md the mode (not {@code null})
+	 * @param numCh the data length in characters or bytes, which is non-negative
+	 * @param data the data bits (not {@code null})
+	 * @param bitLen the number of valid prefix bits in the data array
+	 * @throws NullPointerException if the mode or data is {@code null}
+	 * @throws IllegalArgumentException if the character count is negative
+	 */
+	public QrSegment(Mode md, int numCh, int[] data, int bitLen) {
+		mode = Objects.requireNonNull(md);
+		this.data = Objects.requireNonNull(data);
+		if (numCh < 0 || bitLen < 0 || bitLen > data.length * 32L)
+			throw new IllegalArgumentException("Invalid value");
+		numChars = numCh;
+		bitLength = bitLen;
+	}
+	
+	
+	// Calculates the number of bits needed to encode the given segments at the given version.
+	// Returns a non-negative number if successful. Otherwise returns -1 if a segment has too
+	// many characters to fit its length field, or the total bits exceeds Integer.MAX_VALUE.
+	static int getTotalBits(List<QrSegment> segs, int version) {
+		Objects.requireNonNull(segs);
+		long result = 0;
+		for (QrSegment seg : segs) {
+			Objects.requireNonNull(seg);
+			int ccbits = seg.mode.numCharCountBits(version);
+			if (seg.numChars >= (1 << ccbits))
+				return -1;  // The segment's length doesn't fit the field's bit width
+			result += 4L + ccbits + seg.bitLength;
+			if (result > Integer.MAX_VALUE)
+				return -1;  // The sum will overflow an int type
+		}
+		return (int)result;
+	}
+	
+	
+	/*---- Constants ----*/
+	
+	static final int[] ALPHANUMERIC_MAP;
+	
+	static {
+		final String ALPHANUMERIC_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+		int maxCh = -1;
+		for (int i = 0; i < ALPHANUMERIC_CHARSET.length(); i++)
+			maxCh = Math.max(ALPHANUMERIC_CHARSET.charAt(i), maxCh);
+		ALPHANUMERIC_MAP = new int[maxCh + 1];
+		Arrays.fill(ALPHANUMERIC_MAP, -1);
+		for (int i = 0; i < ALPHANUMERIC_CHARSET.length(); i++)
+			ALPHANUMERIC_MAP[ALPHANUMERIC_CHARSET.charAt(i)] = i;
+	}
+	
+	
+	
+	/*---- Public helper enumeration ----*/
+	
+	/**
+	 * Describes how a segment's data bits are interpreted.
+	 */
+	public enum Mode {
+		
+		/*-- Constants --*/
+		
+		NUMERIC     (0x1, 10, 12, 14),
+		ALPHANUMERIC(0x2,  9, 11, 13),
+		BYTE        (0x4,  8, 16, 16),
+		KANJI       (0x8,  8, 10, 12),
+		ECI         (0x7,  0,  0,  0);
+		
+		
+		/*-- Fields --*/
+		
+		// The mode indicator bits, which is a uint4 value (range 0 to 15).
+		final int modeBits;
+		
+		// Number of character count bits for three different version ranges.
+		private final int[] numBitsCharCount;
+		
+		
+		/*-- Constructor --*/
+		
+		private Mode(int mode, int... ccbits) {
+			modeBits = mode;
+			numBitsCharCount = ccbits;
+		}
+		
+		
+		/*-- Method --*/
+		
+		// Returns the bit width of the character count field for a segment in this mode
+		// in a QR Code at the given version number. The result is in the range [0, 16].
+		int numCharCountBits(int ver) {
+			assert QrCode.MIN_VERSION <= ver && ver <= QrCode.MAX_VERSION;
+			return numBitsCharCount[(ver + 7) / 17];
+		}
+		
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrSegmentAdvanced.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrSegmentAdvanced.java
@@ -1,0 +1,425 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import com.lielamar.auth.bukkit.utils.nayukifast.QrSegment.Mode;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Splits text into optimal segments and encodes kanji segments.
+ * Provides static functions only; not instantiable.
+ * @see QrSegment
+ * @see QrCode
+ */
+public final class QrSegmentAdvanced {
+	
+	/*---- Optimal list of segments encoder ----*/
+	
+	/**
+	 * Returns a list of zero or more segments to represent the specified Unicode text string.
+	 * The resulting list optimally minimizes the total encoded bit length, subjected to the constraints
+	 * in the specified {error correction level, minimum version number, maximum version number}.
+	 * <p>This function can utilize all four text encoding modes: numeric, alphanumeric, byte (UTF-8),
+	 * and kanji. This can be considered as a sophisticated but slower replacement for {@link
+	 * QrSegment#makeSegments(String)}. This requires more input parameters because it searches a
+	 * range of versions, like {@link QrCode#encodeSegments(List,QrCode.Ecc,int,int,int,boolean)}.</p>
+	 * @param text the text to be encoded (not {@code null}), which can be any Unicode string
+	 * @param ecl the error correction level to use (not {@code null})
+	 * @param minVersion the minimum allowed version of the QR Code (at least 1)
+	 * @param maxVersion the maximum allowed version of the QR Code (at most 40)
+	 * @return a new mutable list (not {@code null}) of segments (not {@code null})
+	 * containing the text, minimizing the bit length with respect to the constraints
+	 * @throws NullPointerException if the text or error correction level is {@code null}
+	 * @throws IllegalArgumentException if 1 &#x2264; minVersion &#x2264; maxVersion &#x2264; 40 is violated
+	 * @throws DataTooLongException if the text fails to fit in the maxVersion QR Code at the ECL
+	 */
+	public static List<QrSegment> makeSegmentsOptimally(String text, QrCode.Ecc ecl, int minVersion, int maxVersion) {
+		// Check arguments
+		Objects.requireNonNull(text);
+		Objects.requireNonNull(ecl);
+		if (!(QrCode.MIN_VERSION <= minVersion && minVersion <= maxVersion && maxVersion <= QrCode.MAX_VERSION))
+			throw new IllegalArgumentException("Invalid value");
+		
+		// Iterate through version numbers, and make tentative segments
+		List<QrSegment> segs = null;
+		int[] codePoints = toCodePoints(text);
+		for (int version = minVersion; ; version++) {
+			if (version == minVersion || version == 10 || version == 27)
+				segs = makeSegmentsOptimally(codePoints, version);
+			assert segs != null;
+			
+			// Check if the segments fit
+			int dataCapacityBits = QrCode.getNumDataCodewords(version, ecl) * 8;  // Number of data bits available
+			int dataUsedBits = QrSegment.getTotalBits(segs, version);
+			if (dataUsedBits != -1 && dataUsedBits <= dataCapacityBits)
+				return segs;  // This version number is found to be suitable
+			if (version >= maxVersion) {  // All versions in the range could not fit the given text
+				String msg = "Segment too long";
+				if (dataUsedBits != -1)
+					msg = String.format("Data length = %d bits, Max capacity = %d bits", dataUsedBits, dataCapacityBits);
+				throw new DataTooLongException(msg);
+			}
+		}
+	}
+	
+	
+	// Returns a new list of segments that is optimal for the given text at the given version number.
+	private static List<QrSegment> makeSegmentsOptimally(int[] codePoints, int version) {
+		if (codePoints.length == 0)
+			return new ArrayList<>();
+		Mode[] charModes = computeCharacterModes(codePoints, version);
+		return splitIntoSegments(codePoints, charModes);
+	}
+	
+	
+	// Returns a new array representing the optimal mode per code point based on the given text and version.
+	private static Mode[] computeCharacterModes(int[] codePoints, int version) {
+		if (codePoints.length == 0)
+			throw new IllegalArgumentException();
+		final Mode[] modeTypes = {Mode.BYTE, Mode.ALPHANUMERIC, Mode.NUMERIC, Mode.KANJI};  // Do not modify
+		final int numModes = modeTypes.length;
+		
+		// Segment header sizes, measured in 1/6 bits
+		final int[] headCosts = new int[numModes];
+		for (int i = 0; i < numModes; i++)
+			headCosts[i] = (4 + modeTypes[i].numCharCountBits(version)) * 6;
+		
+		// charModes[i][j] represents the mode to encode the code point at
+		// index i such that the final segment ends in modeTypes[j] and the
+		// total number of bits is minimized over all possible choices
+		Mode[][] charModes = new Mode[codePoints.length][numModes];
+		
+		// At the beginning of each iteration of the loop below,
+		// prevCosts[j] is the exact minimum number of 1/6 bits needed to
+		// encode the entire string prefix of length i, and end in modeTypes[j]
+		int[] prevCosts = headCosts.clone();
+		
+		// Calculate costs using dynamic programming
+		for (int i = 0; i < codePoints.length; i++) {
+			int c = codePoints[i];
+			int[] curCosts = new int[numModes];
+			{  // Always extend a byte mode segment
+				curCosts[0] = prevCosts[0] + countUtf8Bytes(c) * 8 * 6;
+				charModes[i][0] = modeTypes[0];
+			}
+			// Extend a segment if possible
+			if (QrSegment.ALPHANUMERIC_MAP[c] != -1) {  // Is alphanumeric
+				curCosts[1] = prevCosts[1] + 33;  // 5.5 bits per alphanumeric char
+				charModes[i][1] = modeTypes[1];
+			}
+			if ('0' <= c && c <= '9') {  // Is numeric
+				curCosts[2] = prevCosts[2] + 20;  // 3.33 bits per digit
+				charModes[i][2] = modeTypes[2];
+			}
+			if (isKanji(c)) {
+				curCosts[3] = prevCosts[3] + 78;  // 13 bits per Shift JIS char
+				charModes[i][3] = modeTypes[3];
+			}
+			
+			// Start new segment at the end to switch modes
+			for (int j = 0; j < numModes; j++) {  // To mode
+				for (int k = 0; k < numModes; k++) {  // From mode
+					int newCost = (curCosts[k] + 5) / 6 * 6 + headCosts[j];
+					if (charModes[i][k] != null && (charModes[i][j] == null || newCost < curCosts[j])) {
+						curCosts[j] = newCost;
+						charModes[i][j] = modeTypes[k];
+					}
+				}
+			}
+			
+			prevCosts = curCosts;
+		}
+		
+		// Find optimal ending mode
+		Mode curMode = null;
+		for (int i = 0, minCost = 0; i < numModes; i++) {
+			if (curMode == null || prevCosts[i] < minCost) {
+				minCost = prevCosts[i];
+				curMode = modeTypes[i];
+			}
+		}
+		
+		// Get optimal mode for each code point by tracing backwards
+		Mode[] result = new Mode[charModes.length];
+		for (int i = result.length - 1; i >= 0; i--) {
+			for (int j = 0; j < numModes; j++) {
+				if (modeTypes[j] == curMode) {
+					curMode = charModes[i][j];
+					result[i] = curMode;
+					break;
+				}
+			}
+		}
+		return result;
+	}
+	
+	
+	// Returns a new list of segments based on the given text and modes, such that
+	// consecutive code points in the same mode are put into the same segment.
+	private static List<QrSegment> splitIntoSegments(int[] codePoints, Mode[] charModes) {
+		if (codePoints.length == 0)
+			throw new IllegalArgumentException();
+		List<QrSegment> result = new ArrayList<>();
+		
+		// Accumulate run of modes
+		Mode curMode = charModes[0];
+		int start = 0;
+		for (int i = 1; ; i++) {
+			if (i < codePoints.length && charModes[i] == curMode)
+				continue;
+			String s = new String(codePoints, start, i - start);
+			if (curMode == Mode.BYTE)
+				result.add(QrSegment.makeBytes(s.getBytes(StandardCharsets.UTF_8)));
+			else if (curMode == Mode.NUMERIC)
+				result.add(QrSegment.makeNumeric(s));
+			else if (curMode == Mode.ALPHANUMERIC)
+				result.add(QrSegment.makeAlphanumeric(s));
+			else if (curMode == Mode.KANJI)
+				result.add(makeKanji(s));
+			else
+				throw new AssertionError();
+			if (i >= codePoints.length)
+				return result;
+			curMode = charModes[i];
+			start = i;
+		}
+	}
+	
+	
+	// Returns a new array of Unicode code points (effectively
+	// UTF-32 / UCS-4) representing the given UTF-16 string.
+	private static int[] toCodePoints(String s) {
+		int[] result = s.codePoints().toArray();
+		for (int c : result) {
+			if (Character.isSurrogate((char)c))
+				throw new IllegalArgumentException("Invalid UTF-16 string");
+		}
+		return result;
+	}
+	
+	
+	// Returns the number of UTF-8 bytes needed to encode the given Unicode code point.
+	private static int countUtf8Bytes(int cp) {
+		if      (cp <        0) throw new IllegalArgumentException("Invalid code point");
+		else if (cp <     0x80) return 1;
+		else if (cp <    0x800) return 2;
+		else if (cp <  0x10000) return 3;
+		else if (cp < 0x110000) return 4;
+		else                    throw new IllegalArgumentException("Invalid code point");
+	}
+	
+	
+	
+	/*---- Kanji mode segment encoder ----*/
+	
+	/**
+	 * Returns a segment representing the specified text string encoded in kanji mode.
+	 * Broadly speaking, the set of encodable characters are {kanji used in Japan,
+	 * hiragana, katakana, East Asian punctuation, full-width ASCII, Greek, Cyrillic}.
+	 * Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
+	 * more extensive Chinese hanzi}.
+	 * @param text the text (not {@code null}), with only certain characters allowed
+	 * @return a segment (not {@code null}) containing the text
+	 * @throws NullPointerException if the string is {@code null}
+	 * @throws IllegalArgumentException if the string contains non-encodable characters
+	 * @see #isEncodableAsKanji(String)
+	 */
+	public static QrSegment makeKanji(String text) {
+		Objects.requireNonNull(text);
+		BitBuffer bb = new BitBuffer();
+		text.chars().forEachOrdered(c -> {
+			int val = UNICODE_TO_QR_KANJI[c];
+			if (val == -1)
+				throw new IllegalArgumentException("String contains non-kanji-mode characters");
+			bb.appendBits(val, 13);
+		});
+		return new QrSegment(Mode.KANJI, text.length(), bb.data, bb.bitLength);
+	}
+	
+	
+	/**
+	 * Tests whether the specified string can be encoded as a segment in kanji mode.
+	 * Broadly speaking, the set of encodable characters are {kanji used in Japan,
+	 * hiragana, katakana, East Asian punctuation, full-width ASCII, Greek, Cyrillic}.
+	 * Examples of non-encodable characters include {ordinary ASCII, half-width katakana,
+	 * more extensive Chinese hanzi}.
+	 * @param text the string to test for encodability (not {@code null})
+	 * @return {@code true} iff each character is in the kanji mode character set
+	 * @throws NullPointerException if the string is {@code null}
+	 * @see #makeKanji(String)
+	 */
+	public static boolean isEncodableAsKanji(String text) {
+		Objects.requireNonNull(text);
+		return text.chars().allMatch(
+			c -> isKanji((char)c));
+	}
+	
+	
+	private static boolean isKanji(int c) {
+		return c < UNICODE_TO_QR_KANJI.length && UNICODE_TO_QR_KANJI[c] != -1;
+	}
+	
+	
+	// Data derived from ftp://ftp.unicode.org/Public/MAPPINGS/OBSOLETE/EASTASIA/JIS/SHIFTJIS.TXT
+	private static final String PACKED_QR_KANJI_TO_UNICODE =
+		"MAAwATAC/wz/DjD7/xr/G/8f/wEwmzCcALT/QACo/z7/4/8/MP0w/jCdMJ4wA07dMAUwBjAHMPwgFSAQ/w8AXDAcIBb/XCAmICUgGCAZIBwgHf8I/wkwFDAV/zv/Pf9b/10wCDAJMAowCzAMMA0wDjAPMBAwEf8LIhIAsQDX//8A9/8dImD/HP8eImYiZyIeIjQmQiZA" +
+		"ALAgMiAzIQP/5f8EAKIAo/8F/wP/Bv8K/yAApyYGJgUlyyXPJc4lxyXGJaEloCWzJbIlvSW8IDswEiGSIZAhkSGTMBP/////////////////////////////IggiCyKGIocigiKDIioiKf////////////////////8iJyIoAKwh0iHUIgAiA///////////////////" +
+		"//////////8iICKlIxIiAiIHImEiUiJqImsiGiI9Ih0iNSIrIiz//////////////////yErIDAmbyZtJmogICAhALb//////////yXv/////////////////////////////////////////////////xD/Ef8S/xP/FP8V/xb/F/8Y/xn///////////////////8h" +
+		"/yL/I/8k/yX/Jv8n/yj/Kf8q/yv/LP8t/y7/L/8w/zH/Mv8z/zT/Nf82/zf/OP85/zr///////////////////9B/0L/Q/9E/0X/Rv9H/0j/Sf9K/0v/TP9N/07/T/9Q/1H/Uv9T/1T/Vf9W/1f/WP9Z/1r//////////zBBMEIwQzBEMEUwRjBHMEgwSTBKMEswTDBN" +
+		"ME4wTzBQMFEwUjBTMFQwVTBWMFcwWDBZMFowWzBcMF0wXjBfMGAwYTBiMGMwZDBlMGYwZzBoMGkwajBrMGwwbTBuMG8wcDBxMHIwczB0MHUwdjB3MHgweTB6MHswfDB9MH4wfzCAMIEwgjCDMIQwhTCGMIcwiDCJMIowizCMMI0wjjCPMJAwkTCSMJP/////////////" +
+		"////////////////////////MKEwojCjMKQwpTCmMKcwqDCpMKowqzCsMK0wrjCvMLAwsTCyMLMwtDC1MLYwtzC4MLkwujC7MLwwvTC+ML8wwDDBMMIwwzDEMMUwxjDHMMgwyTDKMMswzDDNMM4wzzDQMNEw0jDTMNQw1TDWMNcw2DDZMNow2zDcMN0w3jDf//8w4DDh" +
+		"MOIw4zDkMOUw5jDnMOgw6TDqMOsw7DDtMO4w7zDwMPEw8jDzMPQw9TD2/////////////////////wORA5IDkwOUA5UDlgOXA5gDmQOaA5sDnAOdA54DnwOgA6EDowOkA6UDpgOnA6gDqf////////////////////8DsQOyA7MDtAO1A7YDtwO4A7kDugO7A7wDvQO+" +
+		"A78DwAPBA8MDxAPFA8YDxwPIA8n/////////////////////////////////////////////////////////////////////////////////////////////////////////////BBAEEQQSBBMEFAQVBAEEFgQXBBgEGQQaBBsEHAQdBB4EHwQgBCEEIgQjBCQEJQQm" +
+		"BCcEKAQpBCoEKwQsBC0ELgQv////////////////////////////////////////BDAEMQQyBDMENAQ1BFEENgQ3BDgEOQQ6BDsEPAQ9//8EPgQ/BEAEQQRCBEMERARFBEYERwRIBEkESgRLBEwETQROBE///////////////////////////////////yUAJQIlDCUQ" +
+		"JRglFCUcJSwlJCU0JTwlASUDJQ8lEyUbJRclIyUzJSslOyVLJSAlLyUoJTclPyUdJTAlJSU4JUL/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"/////////////////////////////////////06cVRZaA5Y/VMBhG2MoWfaQIoR1gxx6UGCqY+FuJWXthGaCppv1aJNXJ2WhYnFbm1nQhnuY9H1ifb6bjmIWfJ+It1uJXrVjCWaXaEiVx5eNZ09O5U8KT01PnVBJVvJZN1nUWgFcCWDfYQ9hcGYTaQVwunVPdXB5+32t" +
+		"fe+Aw4QOiGOLApBVkHpTO06VTqVX34CykMF4704AWPFuopA4ejKDKIKLnC9RQVNwVL1U4VbgWftfFZjybeuA5IUt////////lmKWcJagl/tUC1PzW4dwz3+9j8KW6FNvnVx6uk4ReJOB/G4mVhhVBGsdhRqcO1nlU6ltZnTclY9WQk6RkEuW8oNPmQxT4VW2WzBfcWYg" +
+		"ZvNoBGw4bPNtKXRbdsh6Tpg0gvGIW4pgku1tsnWrdsqZxWCmiwGNipWyaY5TrVGG//9XElgwWURbtF72YChjqWP0bL9vFHCOcRRxWXHVcz9+AYJ2gtGFl5BgkludG1hpZbxsWnUlUflZLlllX4Bf3GK8ZfpqKmsna7Rzi3/BiVadLJ0OnsRcoWyWg3tRBFxLYbaBxmh2" +
+		"cmFOWU/6U3hgaW4pek+X804LUxZO7k9VTz1PoU9zUqBT71YJWQ9awVu2W+F50WaHZ5xntmtMbLNwa3PCeY15vno8e4eCsYLbgwSDd4Pvg9OHZoqyVimMqI/mkE6XHoaKT8Rc6GIRcll1O4Hlgr2G/ozAlsWZE5nVTstPGonjVt5YSljKXvtf62AqYJRgYmHQYhJi0GU5" +
+		"////////m0FmZmiwbXdwcHVMdoZ9dYKlh/mVi5aOjJ1R8VK+WRZUs1uzXRZhaGmCba94jYTLiFeKcpOnmrhtbJmohtlXo2f/hs6SDlKDVodUBF7TYuFkuWg8aDhru3NyeLp6a4maidKNa48DkO2Vo5aUl2lbZlyzaX2YTZhOY5t7IGor//9qf2i2nA1vX1JyVZ1gcGLs" +
+		"bTtuB27RhFuJEI9EThScOVP2aRtqOpeEaCpRXHrDhLKR3JOMVludKGgigwWEMXylUgiCxXTmTn5Pg1GgW9JSClLYUudd+1WaWCpZ5luMW5hb215yXnlgo2EfYWNhvmPbZWJn0WhTaPprPmtTbFdvIm+Xb0V0sHUYduN3C3r/e6F8IX3pfzZ/8ICdgmaDnomzisyMq5CE" +
+		"lFGVk5WRlaKWZZfTmSiCGE44VCtcuF3Mc6l2THc8XKl/640LlsGYEZhUmFhPAU8OU3FVnFZoV/pZR1sJW8RckF4MXn5fzGPuZzpl12XiZx9oy2jE////////al9eMGvFbBdsfXV/eUhbY3oAfQBfvYmPihiMtI13jsyPHZjimg6bPE6AUH1RAFmTW5xiL2KAZOxrOnKg" +
+		"dZF5R3+ph/uKvItwY6yDypegVAlUA1WraFRqWIpweCdndZ7NU3RbooEahlCQBk4YTkVOx08RU8pUOFuuXxNgJWVR//9nPWxCbHJs43B4dAN6dnquewh9Gnz+fWZl53JbU7tcRV3oYtJi4GMZbiCGWooxjd2S+G8BeaabWk6oTqtOrE+bT6BQ0VFHevZRcVH2U1RTIVN/" +
+		"U+tVrFiDXOFfN19KYC9gUGBtYx9lWWpLbMFywnLtd++A+IEFggiFTpD3k+GX/5lXmlpO8FHdXC1mgWltXEBm8ml1c4loUHyBUMVS5FdHXf6TJmWkayNrPXQ0eYF5vXtLfcqCuYPMiH+JX4s5j9GR0VQfkoBOXVA2U+VTOnLXc5Z36YLmjq+ZxpnImdJRd2Eahl5VsHp6" +
+		"UHZb05BHloVOMmrbkedcUVxI////////Y5h6n2yTl3SPYXqqcYqWiHyCaBd+cGhRk2xS8lQbhauKE3+kjs2Q4VNmiIh5QU/CUL5SEVFEVVNXLXPqV4tZUV9iX4RgdWF2YWdhqWOyZDplbGZvaEJuE3Vmej18+31MfZl+S39rgw6DSobNigiKY4tmjv2YGp2PgriPzpvo" +
+		"//9Sh2IfZINvwJaZaEFQkWsgbHpvVHp0fVCIQIojZwhO9lA5UCZQZVF8UjhSY1WnVw9YBVrMXvphsmH4YvNjcmkcailyfXKscy54FHhvfXl3DICpiYuLGYzijtKQY5N1lnqYVZoTnnhRQ1OfU7Nee18mbhtukHOEc/59Q4I3igCK+pZQTk5QC1PkVHxW+lnRW2Rd8V6r" +
+		"XydiOGVFZ69uVnLQfMqItIChgOGD8IZOioeN6JI3lseYZ58TTpROkk8NU0hUSVQ+Wi9fjF+hYJ9op2qOdFp4gYqeiqSLd5GQTl6byU6kT3xPr1AZUBZRSVFsUp9SuVL+U5pT41QR////////VA5ViVdRV6JZfVtUW11bj13lXedd9154XoNeml63XxhgUmFMYpdi2GOn" +
+		"ZTtmAmZDZvRnbWghaJdpy2xfbSptaW4vbp11MnaHeGx6P3zgfQV9GH1efbGAFYADgK+AsYFUgY+CKoNSiEyIYYsbjKKM/JDKkXWScXg/kvyVpJZN//+YBZmZmtidO1JbUqtT91QIWNVi92/gjGqPX565UUtSO1RKVv16QJF3nWCe0nNEbwmBcHURX/1g2pqoctuPvGtk" +
+		"mANOylbwV2RYvlpaYGhhx2YPZgZoOWixbfd11X06gm6bQk6bT1BTyVUGXW9d5l3uZ/tsmXRzeAKKUJOWiN9XUF6nYytQtVCsUY1nAFTJWF5Zu1uwX2liTWOhaD1rc24IcH2Rx3KAeBV4JnltZY59MIPciMGPCZabUmRXKGdQf2qMoVG0V0KWKlg6aYqAtFSyXQ5X/HiV" +
+		"nfpPXFJKVItkPmYoZxRn9XqEe1Z9IpMvaFybrXs5UxlRilI3////////W99i9mSuZOZnLWu6hamW0XaQm9ZjTJMGm6t2v2ZSTglQmFPCXHFg6GSSZWNoX3Hmc8p1I3uXfoKGlYuDjNuReJkQZaxmq2uLTtVO1E86T39SOlP4U/JV41bbWOtZy1nJWf9bUFxNXgJeK1/X" +
+		"YB1jB2UvW1xlr2W9ZehnnWti//9re2wPc0V5SXnBfPh9GX0rgKKBAoHziZaKXoppimaKjIrujMeM3JbMmPxrb06LTzxPjVFQW1db+mFIYwFmQmshbstsu3I+dL111HjBeTqADIAzgeqElI+ebFCef18Pi1idK3r6jvhbjZbrTgNT8Vf3WTFayVukYIluf28Gdb6M6luf" +
+		"hQB74FByZ/SCnVxhhUp+HoIOUZlcBGNojWZlnHFueT59F4AFix2OypBuhseQqlAfUvpcOmdTcHxyNZFMkciTK4LlW8JfMWD5TjtT1luIYktnMWuKculz4HougWuNo5FSmZZRElPXVGpb/2OIajl9rJcAVtpTzlRo////////W5dcMV3eT+5hAWL+bTJ5wHnLfUJ+TX/S" +
+		"ge2CH4SQiEaJcouQjnSPL5AxkUuRbJbGkZxOwE9PUUVTQV+TYg5n1GxBbgtzY34mkc2Sg1PUWRlbv23ReV1+LnybWH5xn1H6iFOP8E/KXPtmJXeseuOCHJn/UcZfqmXsaW9riW3z//9ulm9kdv59FF3hkHWRh5gGUeZSHWJAZpFm2W4aXrZ90n9yZviFr4X3ivhSqVPZ" +
+		"WXNej1+QYFWS5JZkULdRH1LdUyBTR1PsVOhVRlUxVhdZaFm+WjxbtVwGXA9cEVwaXoReil7gX3Bif2KEYttjjGN3ZgdmDGYtZnZnfmiiah9qNWy8bYhuCW5YcTxxJnFndcd3AXhdeQF5ZXnweuB7EXynfTmAloPWhIuFSYhdiPOKH4o8ilSKc4xhjN6RpJJmk36UGJac" +
+		"l5hOCk4ITh5OV1GXUnBXzlg0WMxbIl44YMVk/mdhZ1ZtRHK2dXN6Y4S4i3KRuJMgVjFX9Jj+////////Yu1pDWuWce1+VIB3gnKJ5pjfh1WPsVw7TzhP4U+1VQdaIFvdW+lfw2FOYy9lsGZLaO5pm214bfF1M3W5dx95XnnmfTOB44KvhaqJqoo6jquPm5Aykd2XB066" +
+		"TsFSA1h1WOxcC3UaXD2BTooKj8WWY5dteyWKz5gIkWJW81Oo//+QF1Q5V4JeJWOobDRwindhfIt/4IhwkEKRVJMQkxiWj3RemsRdB11pZXBnoo2olttjbmdJaRmDxZgXlsCI/m+EZHpb+E4WcCx1XWYvUcRSNlLiWdNfgWAnYhBlP2V0Zh9mdGjyaBZrY24FcnJ1H3bb" +
+		"fL6AVljwiP2Jf4qgipOKy5AdkZKXUpdZZYl6DoEGlrteLWDcYhplpWYUZ5B383pNfE1+PoEKjKyNZI3hjl94qVIHYtljpWRCYpiKLXqDe8CKrJbqfXaCDIdJTtlRSFNDU2Bbo1wCXBZd3WImYkdksGgTaDRsyW1FbRdn029ccU5xfWXLen97rX3a////////fkp/qIF6" +
+		"ghuCOYWmim6Mzo31kHiQd5KtkpGVg5uuUk1VhG84cTZRaHmFflWBs3zOVkxYUVyoY6pm/mb9aVpy2XWPdY55DnlWed98l30gfUSGB4o0ljuQYZ8gUOdSdVPMU+JQCVWqWO5ZT3I9W4tcZFMdYONg82NcY4NjP2O7//9kzWXpZvld42nNaf1vFXHlTol16Xb4epN8333P" +
+		"fZyAYYNJg1iEbIS8hfuIxY1wkAGQbZOXlxyaElDPWJdhjoHThTWNCJAgT8NQdFJHU3Ngb2NJZ19uLI2zkB9P11xejMplz32aU1KIllF2Y8NbWFtrXApkDWdRkFxO1lkaWSpscIpRVT5YFVmlYPBiU2fBgjVpVZZAmcSaKE9TWAZb/oAQXLFeL1+FYCBhS2I0Zv9s8G7e" +
+		"gM6Bf4LUiIuMuJAAkC6Wip7bm9tO41PwWSd7LJGNmEyd+W7dcCdTU1VEW4ViWGKeYtNsom/vdCKKF5Q4b8GK/oM4UeeG+FPq////////U+lPRpBUj7BZaoExXf166o+/aNqMN3L4nEhqPYqwTjlTWFYGV2ZixWOiZeZrTm3hbltwrXfteu97qn27gD2AxobLipWTW1bj" +
+		"WMdfPmWtZpZqgGu1dTeKx1Akd+VXMF8bYGVmemxgdfR6Gn9ugfSHGJBFmbN7yXVcevl7UYTE//+QEHnpepKDNlrhd0BOLU7yW5lf4GK9Zjxn8WzohmuId4o7kU6S85nQahdwJnMqgueEV4yvTgFRRlHLVYtb9V4WXjNegV8UXzVfa1+0YfJjEWaiZx1vbnJSdTp3OoB0" +
+		"gTmBeId2ir+K3I2FjfOSmpV3mAKc5VLFY1d29GcVbIhzzYzDk66Wc20lWJxpDmnMj/2TmnXbkBpYWmgCY7Rp+09Dbyxn2I+7hSZ9tJNUaT9vcFdqWPdbLH0scipUCpHjnbROrU9OUFxQdVJDjJ5USFgkW5peHV6VXq1e918fYIxitWM6Y9Bor2xAeId5jnoLfeCCR4oC" +
+		"iuaORJAT////////kLiRLZHYnw5s5WRYZOJldW70doR7G5Bpk9FuulTyX7lkpI9Nj+2SRFF4WGtZKVxVXpdt+36PdRyMvI7imFtwuU8da79vsXUwlvtRTlQQWDVYV1msXGBfkmWXZ1xuIXZ7g9+M7ZAUkP2TTXgleDpSql6mVx9ZdGASUBJRWlGs//9RzVIAVRBYVFhY" +
+		"WVdblVz2XYtgvGKVZC1ncWhDaLxo33bXbdhub22bcG9xyF9Tddh5d3tJe1R7UnzWfXFSMIRjhWmF5IoOiwSMRo4PkAOQD5QZlnaYLZowldhQzVLVVAxYAlwOYadknm0ed7N65YD0hASQU5KFXOCdB1M/X5dfs22ccnl3Y3m/e+Rr0nLsiq1oA2phUfh6gWk0XEqc9oLr" +
+		"W8WRSXAeVnhcb2DHZWZsjIxakEGYE1RRZseSDVlIkKNRhU5NUeqFmYsOcFhjepNLaWKZtH4EdXdTV2lgjt+W42xdToxcPF8Qj+lTAozRgImGeV7/ZeVOc1Fl////////WYJcP5fuTvtZil/Nio1v4XmweWJb54RxcytxsV50X/Vje2SaccN8mE5DXvxOS1fcVqJgqW/D" +
+		"fQ2A/YEzgb+PsomXhqRd9GKKZK2Jh2d3bOJtPnQ2eDRaRn91gq2ZrE/zXsNi3WOSZVdnb3bDckyAzIC6jymRTVANV/lakmiF//9pc3Fkcv2Mt1jyjOCWapAZh3955HfnhClPL1JlU1pizWfPbMp2fXuUfJWCNoWEj+tm3W8gcgZ+G4OrmcGeplH9e7F4cnu4gId7SGro" +
+		"XmGAjHVRdWBRa5Jibox2epGXmupPEH9wYpx7T5WlnOlWelhZhuSWvE80UiRTSlPNU9teBmQsZZFnf2w+bE5ySHKvc+11VH5BgiyF6Yype8SRxnFpmBKY72M9Zml1anbkeNCFQ4buUypTUVQmWYNeh198YLJiSWJ5YqtlkGvUbMx1snaueJF52H3Lf3eApYirirmMu5B/" +
+		"l16Y22oLfDhQmVw+X65nh2vYdDV3CX+O////////nztnynoXUzl1i5rtX2aBnYPxgJhfPF/FdWJ7RpA8aGdZ61qbfRB2fossT/VfamoZbDdvAnTieWiIaIpVjHle32PPdcV50oLXkyiS8oSchu2cLVTBX2xljG1ccBWMp4zTmDtlT3T2Tg1O2FfgWStaZlvMUaheA16c" +
+		"YBZidmV3//9lp2ZubW5yNnsmgVCBmoKZi1yMoIzmjXSWHJZET65kq2tmgh6EYYVqkOhcAWlTmKiEeoVXTw9Sb1+pXkVnDXmPgXmJB4mGbfVfF2JVbLhOz3Jpm5JSBlQ7VnRYs2GkYm5xGllufIl83n0blvBlh4BeThlPdVF1WEBeY15zXwpnxE4mhT2ViZZbfHOYAVD7" +
+		"WMF2VninUiV3pYURe4ZQT1kJckd7x33oj7qP1JBNT79SyVopXwGXrU/dgheS6lcDY1VraXUriNyPFHpCUt9Yk2FVYgpmrmvNfD+D6VAjT/hTBVRGWDFZSVudXPBc710pXpZisWNnZT5luWcL////////bNVs4XD5eDJ+K4DegrOEDITshwKJEooqjEqQppLSmP2c851s" +
+		"Tk9OoVCNUlZXSlmoXj1f2F/ZYj9mtGcbZ9Bo0lGSfSGAqoGoiwCMjIy/kn6WMlQgmCxTF1DVU1xYqGSyZzRyZ3dmekaR5lLDbKFrhlgAXkxZVGcsf/tR4XbG//9kaXjom1Seu1fLWblmJ2eaa85U6WnZXlWBnGeVm6pn/pxSaF1Opk/jU8hiuWcrbKuPxE+tfm2ev04H" +
+		"YWJugG8rhRNUc2cqm0Vd83uVXKxbxoccbkqE0XoUgQhZmXyNbBF3IFLZWSJxIXJfd9uXJ51haQtaf1oYUaVUDVR9Zg5234/3kpic9Fnqcl1uxVFNaMl9v33sl2KeumR4aiGDAlmEW19r23MbdvJ9soAXhJlRMmcontl27mdiUv+ZBVwkYjt8foywVU9gtn0LlYBTAU5f" +
+		"UbZZHHI6gDaRzl8ld+JThF95fQSFrIozjo2XVmfzha6UU2EJYQhsuXZS////////iu2POFUvT1FRKlLHU8tbpV59YKBhgmPWZwln2m5nbYxzNnM3dTF5UIjVipiQSpCRkPWWxIeNWRVOiE9ZTg6KiY8/mBBQrV58WZZbuV64Y9pj+mTBZtxpSmnYbQtutnGUdSh6r3+K" +
+		"gACESYTJiYGLIY4KkGWWfZkKYX5ikWsy//9sg210f8x//G3Af4WHuoj4Z2WDsZg8lvdtG31hhD2Rak5xU3VdUGsEb+uFzYYtiadSKVQPXGVnTmiodAZ0g3XiiM+I4ZHMluKWeF+Lc4d6y4ROY6B1ZVKJbUFunHQJdVl4a3ySloZ63J+NT7ZhbmXFhlxOhk6uUNpOIVHM" +
+		"W+5lmWiBbbxzH3ZCd616HHzngm+K0pB8kc+WdZgYUpt90VArU5hnl23LcdB0M4HojyqWo5xXnp90YFhBbZl9L5heTuRPNk+LUbdSsV26YBxzsnk8gtOSNJa3lvaXCp6Xn2Jmpmt0UhdSo3DIiMJeyWBLYZBvI3FJfD599IBv////////hO6QI5MsVEKbb2rTcImMwo3v" +
+		"lzJStFpBXspfBGcXaXxplG1qbw9yYnL8e+2AAYB+h0uQzlFtnpN5hICLkzKK1lAtVIyKcWtqjMSBB2DRZ6Cd8k6ZTpicEIprhcGFaGkAbn54l4FV////////////////////////////////////////////////////////////////////////////////////////" +
+		"/////////////////////////////18MThBOFU4qTjFONk48Tj9OQk5WTlhOgk6FjGtOioISXw1Ojk6eTp9OoE6iTrBOs062Ts5OzU7ETsZOwk7XTt5O7U7fTvdPCU9aTzBPW09dT1dPR092T4hPj0+YT3tPaU9wT5FPb0+GT5ZRGE/UT99Pzk/YT9tP0U/aT9BP5E/l" +
+		"UBpQKFAUUCpQJVAFTxxP9lAhUClQLE/+T+9QEVAGUENQR2cDUFVQUFBIUFpQVlBsUHhQgFCaUIVQtFCy////////UMlQylCzUMJQ1lDeUOVQ7VDjUO5Q+VD1UQlRAVECURZRFVEUURpRIVE6UTdRPFE7UT9RQFFSUUxRVFFievhRaVFqUW5RgFGCVthRjFGJUY9RkVGT" +
+		"UZVRllGkUaZRolGpUapRq1GzUbFRslGwUbVRvVHFUclR21HghlVR6VHt//9R8FH1Uf5SBFILUhRSDlInUipSLlIzUjlST1JEUktSTFJeUlRSalJ0UmlSc1J/Un1SjVKUUpJScVKIUpGPqI+nUqxSrVK8UrVSwVLNUtdS3lLjUuaY7VLgUvNS9VL4UvlTBlMIdThTDVMQ" +
+		"Uw9TFVMaUyNTL1MxUzNTOFNAU0ZTRU4XU0lTTVHWU15TaVNuWRhTe1N3U4JTllOgU6ZTpVOuU7BTtlPDfBKW2VPfZvxx7lPuU+hT7VP6VAFUPVRAVCxULVQ8VC5UNlQpVB1UTlSPVHVUjlRfVHFUd1RwVJJUe1SAVHZUhFSQVIZUx1SiVLhUpVSsVMRUyFSo////////" +
+		"VKtUwlSkVL5UvFTYVOVU5lUPVRRU/VTuVO1U+lTiVTlVQFVjVUxVLlVcVUVVVlVXVThVM1VdVZlVgFSvVYpVn1V7VX5VmFWeVa5VfFWDValVh1WoVdpVxVXfVcRV3FXkVdRWFFX3VhZV/lX9VhtV+VZOVlBx31Y0VjZWMlY4//9Wa1ZkVi9WbFZqVoZWgFaKVqBWlFaP" +
+		"VqVWrla2VrRWwla8VsFWw1bAVshWzlbRVtNW11buVvlXAFb/VwRXCVcIVwtXDVcTVxhXFlXHVxxXJlc3VzhXTlc7V0BXT1dpV8BXiFdhV39XiVeTV6BXs1ekV6pXsFfDV8ZX1FfSV9NYClfWV+NYC1gZWB1YclghWGJYS1hwa8BYUlg9WHlYhVi5WJ9Yq1i6WN5Yu1i4" +
+		"WK5YxVjTWNFY11jZWNhY5VjcWORY31jvWPpY+Vj7WPxY/VkCWQpZEFkbaKZZJVksWS1ZMlk4WT560llVWVBZTllaWVhZYllgWWdZbFlp////////WXhZgVmdT15Pq1mjWbJZxlnoWdxZjVnZWdpaJVofWhFaHFoJWhpaQFpsWklaNVo2WmJaalqaWrxavlrLWsJavVrj" +
+		"Wtda5lrpWtZa+lr7WwxbC1sWWzJa0FsqWzZbPltDW0VbQFtRW1VbWltbW2VbaVtwW3NbdVt4ZYhbeluA//9bg1umW7hbw1vHW8lb1FvQW+Rb5lviW95b5VvrW/Bb9lvzXAVcB1wIXA1cE1wgXCJcKFw4XDlcQVxGXE5cU1xQXE9bcVxsXG5OYlx2XHlcjFyRXJRZm1yr" +
+		"XLtctly8XLdcxVy+XMdc2VzpXP1c+lztXYxc6l0LXRVdF11cXR9dG10RXRRdIl0aXRldGF1MXVJdTl1LXWxdc112XYddhF2CXaJdnV2sXa5dvV2QXbddvF3JXc1d013SXdZd213rXfJd9V4LXhpeGV4RXhteNl43XkReQ15AXk5eV15UXl9eYl5kXkdedV52XnqevF5/" +
+		"XqBewV7CXshe0F7P////////XtZe417dXtpe217iXuFe6F7pXuxe8V7zXvBe9F74Xv5fA18JX11fXF8LXxFfFl8pXy1fOF9BX0hfTF9OXy9fUV9WX1dfWV9hX21fc193X4Nfgl9/X4pfiF+RX4dfnl+ZX5hfoF+oX61fvF/WX/tf5F/4X/Ff3WCzX/9gIWBg//9gGWAQ" +
+		"YClgDmAxYBtgFWArYCZgD2A6YFpgQWBqYHdgX2BKYEZgTWBjYENgZGBCYGxga2BZYIFgjWDnYINgmmCEYJtglmCXYJJgp2CLYOFguGDgYNNgtF/wYL1gxmC1YNhhTWEVYQZg9mD3YQBg9GD6YQNhIWD7YPFhDWEOYUdhPmEoYSdhSmE/YTxhLGE0YT1hQmFEYXNhd2FY" +
+		"YVlhWmFrYXRhb2FlYXFhX2FdYVNhdWGZYZZhh2GsYZRhmmGKYZFhq2GuYcxhymHJYfdhyGHDYcZhumHLf3lhzWHmYeNh9mH6YfRh/2H9Yfxh/mIAYghiCWINYgxiFGIb////////Yh5iIWIqYi5iMGIyYjNiQWJOYl5iY2JbYmBiaGJ8YoJiiWJ+YpJik2KWYtRig2KU" +
+		"Ytdi0WK7Ys9i/2LGZNRiyGLcYsxiymLCYsdim2LJYwxi7mLxYydjAmMIYu9i9WNQYz5jTWQcY09jlmOOY4Bjq2N2Y6Njj2OJY59jtWNr//9jaWO+Y+ljwGPGY+NjyWPSY/ZjxGQWZDRkBmQTZCZkNmUdZBdkKGQPZGdkb2R2ZE5lKmSVZJNkpWSpZIhkvGTaZNJkxWTH" +
+		"ZLtk2GTCZPFk54IJZOBk4WKsZONk72UsZPZk9GTyZPplAGT9ZRhlHGUFZSRlI2UrZTRlNWU3ZTZlOHVLZUhlVmVVZU1lWGVeZV1lcmV4ZYJlg4uKZZtln2WrZbdlw2XGZcFlxGXMZdJl22XZZeBl4WXxZ3JmCmYDZftnc2Y1ZjZmNGYcZk9mRGZJZkFmXmZdZmRmZ2Zo" +
+		"Zl9mYmZwZoNmiGaOZolmhGaYZp1mwWa5Zslmvma8////////ZsRmuGbWZtpm4GY/ZuZm6WbwZvVm92cPZxZnHmcmZyeXOGcuZz9nNmdBZzhnN2dGZ15nYGdZZ2NnZGeJZ3BnqWd8Z2pnjGeLZ6ZnoWeFZ7dn72e0Z+xns2fpZ7hn5GfeZ91n4mfuZ7lnzmfGZ+dqnGge" +
+		"aEZoKWhAaE1oMmhO//9os2graFloY2h3aH9on2iPaK1olGidaJtog2quaLlodGi1aKBoumkPaI1ofmkBaMppCGjYaSJpJmjhaQxozWjUaOdo1Wk2aRJpBGjXaONpJWj5aOBo72koaSppGmkjaSFoxml5aXdpXGl4aWtpVGl+aW5pOWl0aT1pWWkwaWFpXmldaYFpammy" +
+		"aa5p0Gm/acFp02m+ac5b6GnKad1pu2nDaadqLmmRaaBpnGmVabRp3mnoagJqG2n/awpp+WnyaedqBWmxah5p7WoUaetqCmoSasFqI2oTakRqDGpyajZqeGpHamJqWWpmakhqOGoiapBqjWqgaoRqomqj////////apeGF2q7asNqwmq4arNqrGreatFq32qqatpq6mr7" +
+		"awWGFmr6axJrFpsxax9rOGs3dtxrOZjua0drQ2tJa1BrWWtUa1trX2tha3hreWt/a4BrhGuDa41rmGuVa55rpGuqa6trr2uya7Frs2u3a7xrxmvLa9Nr32vsa+tr82vv//+evmwIbBNsFGwbbCRsI2xebFVsYmxqbIJsjWyabIFsm2x+bGhsc2ySbJBsxGzxbNNsvWzX" +
+		"bMVs3WyubLFsvmy6bNts72zZbOptH4hNbTZtK209bThtGW01bTNtEm0MbWNtk21kbVpteW1ZbY5tlW/kbYVt+W4VbgpttW3HbeZtuG3Gbext3m3Mbeht0m3Fbfpt2W3kbdVt6m3ubi1ubm4ubhlucm5fbj5uI25rbitudm5Nbh9uQ246bk5uJG7/bh1uOG6CbqpumG7J" +
+		"brdu0269bq9uxG6ybtRu1W6PbqVuwm6fb0FvEXBMbuxu+G7+bz9u8m8xbu9vMm7M////////bz5vE273b4Zvem94b4FvgG9vb1tv829tb4JvfG9Yb45vkW/Cb2Zvs2+jb6FvpG+5b8Zvqm/fb9Vv7G/Ub9hv8W/ub9twCXALb/pwEXABcA9v/nAbcBpvdHAdcBhwH3Aw" +
+		"cD5wMnBRcGNwmXCScK9w8XCscLhws3CucN9wy3Dd//9w2XEJcP1xHHEZcWVxVXGIcWZxYnFMcVZxbHGPcftxhHGVcahxrHHXcblxvnHScclx1HHOceBx7HHncfVx/HH5cf9yDXIQchtyKHItcixyMHIycjtyPHI/ckByRnJLclhydHJ+coJygXKHcpJylnKicqdyuXKy" +
+		"csNyxnLEcs5y0nLicuBy4XL5cvdQD3MXcwpzHHMWcx1zNHMvcylzJXM+c05zT57Yc1dzanNoc3BzeHN1c3tzenPIc7NzznO7c8Bz5XPuc950onQFdG90JXP4dDJ0OnRVdD90X3RZdEF0XHRpdHB0Y3RqdHZ0fnSLdJ50p3TKdM901HPx////////dOB043TndOl07nTy" +
+		"dPB08XT4dPd1BHUDdQV1DHUOdQ11FXUTdR51JnUsdTx1RHVNdUp1SXVbdUZ1WnVpdWR1Z3VrdW11eHV2dYZ1h3V0dYp1iXWCdZR1mnWddaV1o3XCdbN1w3W1db11uHW8dbF1zXXKddJ12XXjdd51/nX///91/HYBdfB1+nXydfN2C3YNdgl2H3YndiB2IXYidiR2NHYw" +
+		"djt2R3ZIdkZ2XHZYdmF2YnZodml2anZndmx2cHZydnZ2eHZ8doB2g3aIdot2jnaWdpN2mXaadrB2tHa4drl2unbCds121nbSdt524Xbldud26oYvdvt3CHcHdwR3KXckdx53JXcmdxt3N3c4d0d3Wndod2t3W3dld393fnd5d453i3eRd6B3nnewd7Z3uXe/d7x3vXe7" +
+		"d8d3zXfXd9p33Hfjd+53/HgMeBJ5JnggeSp4RXiOeHR4hnh8eJp4jHijeLV4qniveNF4xnjLeNR4vni8eMV4ynjs////////eOd42nj9ePR5B3kSeRF5GXkseSt5QHlgeVd5X3laeVV5U3l6eX95inmdeaefS3mqea55s3m5ebp5yXnVeed57HnheeN6CHoNehh6GXog" +
+		"eh95gHoxejt6Pno3ekN6V3pJemF6Ynppn516cHp5en16iHqXepV6mHqWeql6yHqw//96tnrFesR6v5CDesd6ynrNes961XrTetl62nrdeuF64nrmeu168HsCew97CnsGezN7GHsZex57NXsoezZ7UHt6ewR7TXsLe0x7RXt1e2V7dHtne3B7cXtse257nXuYe597jXuc" +
+		"e5p7i3uSe497XXuZe8t7wXvMe897tHvGe9176XwRfBR75nvlfGB8AHwHfBN783v3fBd8DXv2fCN8J3wqfB98N3wrfD18THxDfFR8T3xAfFB8WHxffGR8VnxlfGx8dXyDfJB8pHytfKJ8q3yhfKh8s3yyfLF8rny5fL18wHzFfMJ82HzSfNx84ps7fO988nz0fPZ8+n0G" +
+		"////////fQJ9HH0VfQp9RX1LfS59Mn0/fTV9Rn1zfVZ9Tn1yfWh9bn1PfWN9k32JfVt9j319fZt9un2ufaN9tX3Hfb19q349faJ9r33cfbh9n32wfdh93X3kfd59+33yfeF+BX4KfiN+IX4SfjF+H34Jfgt+In5GfmZ+O341fjl+Q343//9+Mn46fmd+XX5Wfl5+WX5a" +
+		"fnl+an5pfnx+e36DfdV+fY+ufn9+iH6Jfox+kn6QfpN+lH6Wfo5+m36cfzh/On9Ff0x/TX9Of1B/UX9Vf1R/WH9ff2B/aH9pf2d/eH+Cf4Z/g3+If4d/jH+Uf55/nX+af6N/r3+yf7l/rn+2f7iLcX/Ff8Z/yn/Vf9R/4X/mf+l/83/5mNyABoAEgAuAEoAYgBmAHIAh" +
+		"gCiAP4A7gEqARoBSgFiAWoBfgGKAaIBzgHKAcIB2gHmAfYB/gISAhoCFgJuAk4CagK1RkICsgNuA5YDZgN2AxIDagNaBCYDvgPGBG4EpgSOBL4FL////////louBRoE+gVOBUYD8gXGBboFlgWaBdIGDgYiBioGAgYKBoIGVgaSBo4FfgZOBqYGwgbWBvoG4gb2BwIHC" +
+		"gbqByYHNgdGB2YHYgciB2oHfgeCB54H6gfuB/oIBggKCBYIHggqCDYIQghaCKYIrgjiCM4JAglmCWIJdglqCX4Jk//+CYoJogmqCa4IugnGCd4J4gn6CjYKSgquCn4K7gqyC4YLjgt+C0oL0gvOC+oOTgwOC+4L5gt6DBoLcgwmC2YM1gzSDFoMygzGDQIM5g1CDRYMv" +
+		"gyuDF4MYg4WDmoOqg5+DooOWgyODjoOHg4qDfIO1g3ODdYOgg4mDqIP0hBOD64POg/2EA4PYhAuDwYP3hAeD4IPyhA2EIoQgg72EOIUGg/uEbYQqhDyFWoSEhHeEa4SthG6EgoRphEaELIRvhHmENYTKhGKEuYS/hJ+E2YTNhLuE2oTQhMGExoTWhKGFIYT/hPSFF4UY" +
+		"hSyFH4UVhRSE/IVAhWOFWIVI////////hUGGAoVLhVWFgIWkhYiFkYWKhaiFbYWUhZuF6oWHhZyFd4V+hZCFyYW6hc+FuYXQhdWF3YXlhdyF+YYKhhOGC4X+hfqGBoYihhqGMIY/hk1OVYZUhl+GZ4ZxhpOGo4aphqqGi4aMhraGr4bEhsaGsIbJiCOGq4bUht6G6Ybs" +
+		"//+G34bbhu+HEocGhwiHAIcDhvuHEYcJhw2G+YcKhzSHP4c3hzuHJYcphxqHYIdfh3iHTIdOh3SHV4doh26HWYdTh2OHaogFh6KHn4eCh6+Hy4e9h8CH0JbWh6uHxIezh8eHxoe7h++H8ofgiA+IDYf+h/aH94gOh9KIEYgWiBWIIoghiDGINog5iCeIO4hEiEKIUohZ" +
+		"iF6IYohriIGIfoieiHWIfYi1iHKIgoiXiJKIroiZiKKIjYikiLCIv4ixiMOIxIjUiNiI2YjdiPmJAoj8iPSI6IjyiQSJDIkKiROJQ4keiSWJKokriUGJRIk7iTaJOIlMiR2JYIle////////iWaJZIltiWqJb4l0iXeJfomDiYiJiomTiZiJoYmpiaaJrImvibKJuom9" +
+		"ib+JwInaidyJ3YnnifSJ+IoDihaKEIoMihuKHYolijaKQYpbilKKRopIinyKbYpsimKKhYqCioSKqIqhipGKpYqmipqKo4rEis2KworaiuuK84rn//+K5IrxixSK4IriiveK3orbiwyLB4saiuGLFosQixeLIIszl6uLJosriz6LKItBi0yLT4tOi0mLVotbi1qLa4tf" +
+		"i2yLb4t0i32LgIuMi46LkouTi5aLmYuajDqMQYw/jEiMTIxOjFCMVYxijGyMeIx6jIKMiYyFjIqMjYyOjJSMfIyYYh2MrYyqjL2MsoyzjK6MtozIjMGM5IzjjNqM/Yz6jPuNBI0FjQqNB40PjQ2NEJ9OjROMzY0UjRaNZ41tjXGNc42BjZmNwo2+jbqNz43ajdaNzI3b" +
+		"jcuN6o3rjd+N4438jgiOCY3/jh2OHo4Qjh+OQo41jjCONI5K////////jkeOSY5MjlCOSI5ZjmSOYI4qjmOOVY52jnKOfI6BjoeOhY6EjouOio6TjpGOlI6ZjqqOoY6sjrCOxo6xjr6OxY7IjsuO247jjvyO+47rjv6PCo8FjxWPEo8ZjxOPHI8fjxuPDI8mjzOPO485" +
+		"j0WPQo8+j0yPSY9Gj06PV49c//+PYo9jj2SPnI+fj6OPrY+vj7eP2o/lj+KP6o/vkIeP9JAFj/mP+pARkBWQIZANkB6QFpALkCeQNpA1kDmP+JBPkFCQUZBSkA6QSZA+kFaQWJBekGiQb5B2lqiQcpCCkH2QgZCAkIqQiZCPkKiQr5CxkLWQ4pDkYkiQ25ECkRKRGZEy" +
+		"kTCRSpFWkViRY5FlkWmRc5FykYuRiZGCkaKRq5GvkaqRtZG0kbqRwJHBkcmRy5HQkdaR35HhkduR/JH1kfaSHpH/khSSLJIVkhGSXpJXkkWSSZJkkkiSlZI/kkuSUJKckpaSk5KbklqSz5K5kreS6ZMPkvqTRJMu////////kxmTIpMakyOTOpM1kzuTXJNgk3yTbpNW" +
+		"k7CTrJOtk5STuZPWk9eT6JPlk9iTw5Pdk9CTyJPklBqUFJQTlAOUB5QQlDaUK5Q1lCGUOpRBlFKURJRblGCUYpRelGqSKZRwlHWUd5R9lFqUfJR+lIGUf5WClYeVipWUlZaVmJWZ//+VoJWolaeVrZW8lbuVuZW+lcpv9pXDlc2VzJXVldSV1pXcleGV5ZXiliGWKJYu" +
+		"li+WQpZMlk+WS5Z3llyWXpZdll+WZpZylmyWjZaYlpWWl5aqlqeWsZaylrCWtJa2lriWuZbOlsuWyZbNiU2W3JcNltWW+ZcElwaXCJcTlw6XEZcPlxaXGZcklyqXMJc5lz2XPpdEl0aXSJdCl0mXXJdgl2SXZpdoUtKXa5dxl3mXhZd8l4GXepeGl4uXj5eQl5yXqJem" +
+		"l6OXs5e0l8OXxpfIl8uX3Jftn0+X8nrfl/aX9ZgPmAyYOJgkmCGYN5g9mEaYT5hLmGuYb5hw////////mHGYdJhzmKqYr5ixmLaYxJjDmMaY6ZjrmQOZCZkSmRSZGJkhmR2ZHpkkmSCZLJkumT2ZPplCmUmZRZlQmUuZUZlSmUyZVZmXmZiZpZmtma6ZvJnfmduZ3ZnY" +
+		"mdGZ7ZnumfGZ8pn7mfiaAZoPmgWZ4poZmiuaN5pFmkKaQJpD//+aPppVmk2aW5pXml+aYpplmmSaaZprmmqarZqwmryawJrPmtGa05rUmt6a35rimuOa5prvmuua7pr0mvGa95r7mwabGJsamx+bIpsjmyWbJ5somymbKpsumy+bMptEm0ObT5tNm06bUZtYm3Sbk5uD" +
+		"m5GblpuXm5+boJuom7SbwJvKm7mbxpvPm9Gb0pvjm+Kb5JvUm+GcOpvym/Gb8JwVnBScCZwTnAycBpwInBKcCpwEnC6cG5wlnCScIZwwnEecMpxGnD6cWpxgnGecdpx4nOec7JzwnQmdCJzrnQOdBp0qnSadr50jnR+dRJ0VnRKdQZ0/nT6dRp1I////////nV2dXp1k" +
+		"nVGdUJ1ZnXKdiZ2Hnaudb516nZqdpJ2pnbKdxJ3BnbuduJ26ncadz53Cndmd0534nead7Z3vnf2eGp4bnh6edZ55nn2egZ6InouejJ6SnpWekZ6dnqWeqZ64nqqerZdhnsyezp7PntCe1J7cnt6e3Z7gnuWe6J7v//+e9J72nvee+Z77nvye/Z8Hnwh2t58VnyGfLJ8+" +
+		"n0qfUp9Un2OfX59gn2GfZp9nn2yfap93n3Kfdp+Vn5yfoFgvaceQWXRkUdxxmf//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////" +
+		"/////////////////////////////////////////////w==";
+	
+	
+	private static short[] UNICODE_TO_QR_KANJI = new short[1 << 16];
+	
+	static {  // Unpack the Shift JIS table into a more computation-friendly form
+		Arrays.fill(UNICODE_TO_QR_KANJI, (short)-1);
+		byte[] bytes = Base64.getDecoder().decode(PACKED_QR_KANJI_TO_UNICODE);
+		for (int i = 0; i < bytes.length; i += 2) {
+			char c = (char)(((bytes[i] & 0xFF) << 8) | (bytes[i + 1] & 0xFF));
+			if (c == 0xFFFF)
+				continue;
+			assert UNICODE_TO_QR_KANJI[c] == -1;
+			UNICODE_TO_QR_KANJI[c] = (short)(i / 2);
+		}
+	}
+	
+	
+	
+	/*---- Miscellaneous ----*/
+	
+	private QrSegmentAdvanced() {}  // Not instantiable
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrTemplate.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/QrTemplate.java
@@ -1,0 +1,270 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+
+// Stores the parts of a QR Code that depend only on the version number,
+// and does not depend on the data or error correction level or mask.
+final class QrTemplate {
+	
+	// Use this memoizer to get instances of this class.
+	public static final Memoizer<Integer,QrTemplate> MEMOIZER
+		= new Memoizer<>(QrTemplate::new);
+	
+	
+	private final int version;  // In the range [1, 40].
+	private final int size;  // Derived from version.
+	
+	final int[] template;  // Length and values depend on version.
+	final int[][] masks;  // masks.length == 8, and masks[i].length == template.length.
+	final int[] dataOutputBitIndexes;  // Length and values depend on version.
+	
+	// Indicates function modules that are not subjected to masking. Discarded when constructor finishes.
+	// Otherwise when the constructor is running, isFunction.length == template.length.
+	private int[] isFunction;
+	
+	
+	// Creates a QR Code template for the given version number.
+	private QrTemplate(int ver) {
+		if (ver < QrCode.MIN_VERSION || ver > QrCode.MAX_VERSION)
+			throw new IllegalArgumentException("Version out of range");
+		version = ver;
+		size = version * 4 + 17;
+		template = new int[(size * size + 31) / 32];
+		isFunction = new int[template.length];
+		
+		drawFunctionPatterns();  // Reads and writes fields
+		masks = generateMasks();  // Reads fields, returns array
+		dataOutputBitIndexes = generateZigzagScan();  // Reads fields, returns array
+		isFunction = null;
+	}
+	
+	
+	// Reads this object's version field, and draws and marks all function modules.
+	private void drawFunctionPatterns() {
+		// Draw horizontal and vertical timing patterns
+		for (int i = 0; i < size; i++) {
+			darkenFunctionModule(6, i, ~i & 1);
+			darkenFunctionModule(i, 6, ~i & 1);
+		}
+		
+		// Draw 3 finder patterns (all corners except bottom right; overwrites some timing modules)
+		drawFinderPattern(3, 3);
+		drawFinderPattern(size - 4, 3);
+		drawFinderPattern(3, size - 4);
+		
+		// Draw numerous alignment patterns
+		int[] alignPatPos = getAlignmentPatternPositions();
+		int numAlign = alignPatPos.length;
+		for (int i = 0; i < numAlign; i++) {
+			for (int j = 0; j < numAlign; j++) {
+				// Don't draw on the three finder corners
+				if (!(i == 0 && j == 0 || i == 0 && j == numAlign - 1 || i == numAlign - 1 && j == 0))
+					drawAlignmentPattern(alignPatPos[i], alignPatPos[j]);
+			}
+		}
+		
+		// Draw configuration data
+		drawDummyFormatBits();
+		drawVersion();
+	}
+	
+	
+	// Draws two blank copies of the format bits.
+	private void drawDummyFormatBits() {
+		// Draw first copy
+		for (int i = 0; i <= 5; i++)
+			darkenFunctionModule(8, i, 0);
+		darkenFunctionModule(8, 7, 0);
+		darkenFunctionModule(8, 8, 0);
+		darkenFunctionModule(7, 8, 0);
+		for (int i = 9; i < 15; i++)
+			darkenFunctionModule(14 - i, 8, 0);
+		
+		// Draw second copy
+		for (int i = 0; i < 8; i++)
+			darkenFunctionModule(size - 1 - i, 8, 0);
+		for (int i = 8; i < 15; i++)
+			darkenFunctionModule(8, size - 15 + i, 0);
+		darkenFunctionModule(8, size - 8, 1);  // Always dark
+	}
+	
+	
+	// Draws two copies of the version bits (with its own error correction code),
+	// based on this object's version field, iff 7 <= version <= 40.
+	private void drawVersion() {
+		if (version < 7)
+			return;
+		
+		// Calculate error correction code and pack bits
+		int rem = version;  // version is uint6, in the range [7, 40]
+		for (int i = 0; i < 12; i++)
+			rem = (rem << 1) ^ ((rem >>> 11) * 0x1F25);
+		int bits = version << 12 | rem;  // uint18
+		assert bits >>> 18 == 0;
+		
+		// Draw two copies
+		for (int i = 0; i < 18; i++) {
+			int bit = QrCode.getBit(bits, i);
+			int a = size - 11 + i % 3;
+			int b = i / 3;
+			darkenFunctionModule(a, b, bit);
+			darkenFunctionModule(b, a, bit);
+		}
+	}
+	
+	
+	// Draws a 9*9 finder pattern including the border separator,
+	// with the center module at (x, y). Modules can be out of bounds.
+	private void drawFinderPattern(int x, int y) {
+		for (int dy = -4; dy <= 4; dy++) {
+			for (int dx = -4; dx <= 4; dx++) {
+				int dist = Math.max(Math.abs(dx), Math.abs(dy));  // Chebyshev/infinity norm
+				int xx = x + dx, yy = y + dy;
+				if (0 <= xx && xx < size && 0 <= yy && yy < size)
+					darkenFunctionModule(xx, yy, (dist != 2 && dist != 4) ? 1 : 0);
+			}
+		}
+	}
+	
+	
+	// Draws a 5*5 alignment pattern, with the center module
+	// at (x, y). All modules must be in bounds.
+	private void drawAlignmentPattern(int x, int y) {
+		for (int dy = -2; dy <= 2; dy++) {
+			for (int dx = -2; dx <= 2; dx++)
+				darkenFunctionModule(x + dx, y + dy, Math.abs(Math.max(Math.abs(dx), Math.abs(dy)) - 1));
+		}
+	}
+	
+	
+	// Computes and returns a new array of masks, based on this object's various fields.
+	private int[][] generateMasks() {
+		int[][] result = new int[8][template.length];
+		for (int mask = 0; mask < result.length; mask++) {
+			int[] maskModules = result[mask];
+			for (int y = 0, i = 0; y < size; y++) {
+				for (int x = 0; x < size; x++, i++) {
+					boolean invert;
+					switch (mask) {
+						case 0:  invert = (x + y) % 2 == 0;                    break;
+						case 1:  invert = y % 2 == 0;                          break;
+						case 2:  invert = x % 3 == 0;                          break;
+						case 3:  invert = (x + y) % 3 == 0;                    break;
+						case 4:  invert = (x / 3 + y / 2) % 2 == 0;            break;
+						case 5:  invert = x * y % 2 + x * y % 3 == 0;          break;
+						case 6:  invert = (x * y % 2 + x * y % 3) % 2 == 0;    break;
+						case 7:  invert = ((x + y) % 2 + x * y % 3) % 2 == 0;  break;
+						default:  throw new AssertionError();
+					}
+					int bit = (invert ? 1 : 0) & ~getModule(isFunction, x, y);
+					maskModules[i >>> 5] |= bit << i;
+				}
+			}
+		}
+		return result;
+	}
+	
+	
+	// Computes and returns an array of bit indexes, based on this object's various fields.
+	private int[] generateZigzagScan() {
+		int[] result = new int[getNumRawDataModules(version) / 8 * 8];
+		int i = 0;  // Bit index into the data
+		for (int right = size - 1; right >= 1; right -= 2) {  // Index of right column in each column pair
+			if (right == 6)
+				right = 5;
+			for (int vert = 0; vert < size; vert++) {  // Vertical counter
+				for (int j = 0; j < 2; j++) {
+					int x = right - j;  // Actual x coordinate
+					boolean upward = ((right + 1) & 2) == 0;
+					int y = upward ? size - 1 - vert : vert;  // Actual y coordinate
+					if (getModule(isFunction, x, y) == 0 && i < result.length) {
+						result[i] = y * size + x;
+						i++;
+					}
+				}
+			}
+		}
+		assert i == result.length;
+		return result;
+	}
+	
+	
+	// Returns the value of the bit at the given coordinates in the given grid.
+	private int getModule(int[] grid, int x, int y) {
+		assert 0 <= x && x < size;
+		assert 0 <= y && y < size;
+		int i = y * size + x;
+		return QrCode.getBit(grid[i >>> 5], i);
+	}
+	
+	
+	// Marks the module at the given coordinates as a function module.
+	// Also either sets that module dark or keeps its color unchanged.
+	private void darkenFunctionModule(int x, int y, int enable) {
+		assert 0 <= x && x < size;
+		assert 0 <= y && y < size;
+		assert enable == 0 || enable == 1;
+		int i = y * size + x;
+		template[i >>> 5] |= enable << i;
+		isFunction[i >>> 5] |= 1 << i;
+	}
+	
+	
+	// Returns an ascending list of positions of alignment patterns for this version number.
+	// Each position is in the range [0,177), and are used on both the x and y axes.
+	// This could be implemented as lookup table of 40 variable-length lists of unsigned bytes.
+	private int[] getAlignmentPatternPositions() {
+		if (version == 1)
+			return new int[]{};
+		else {
+			int numAlign = version / 7 + 2;
+			int step = (version == 32) ? 26 :
+				(version * 4 + numAlign * 2 + 1) / (numAlign * 2 - 2) * 2;
+			int[] result = new int[numAlign];
+			result[0] = 6;
+			for (int i = result.length - 1, pos = size - 7; i >= 1; i--, pos -= step)
+				result[i] = pos;
+			return result;
+		}
+	}
+	
+	
+	// Returns the number of data bits that can be stored in a QR Code of the given version number, after
+	// all function modules are excluded. This includes remainder bits, so it might not be a multiple of 8.
+	// The result is in the range [208, 29648]. This could be implemented as a 40-entry lookup table.
+	static int getNumRawDataModules(int ver) {
+		if (ver < QrCode.MIN_VERSION || ver > QrCode.MAX_VERSION)
+			throw new IllegalArgumentException("Version number out of range");
+		int result = (16 * ver + 128) * ver + 64;
+		if (ver >= 2) {
+			int numAlign = ver / 7 + 2;
+			result -= (25 * numAlign - 10) * numAlign - 55;
+			if (ver >= 7)
+				result -= 36;
+		}
+		return result;
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/ReedSolomonGenerator.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/ReedSolomonGenerator.java
@@ -1,0 +1,106 @@
+/* 
+ * Fast QR Code generator library
+ * 
+ * Copyright (c) Project Nayuki. (MIT License)
+ * https://www.nayuki.io/page/fast-qr-code-generator-library
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * - The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ * - The Software is provided "as is", without warranty of any kind, express or
+ *   implied, including but not limited to the warranties of merchantability,
+ *   fitness for a particular purpose and noninfringement. In no event shall the
+ *   authors or copyright holders be liable for any claim, damages or other
+ *   liability, whether in an action of contract, tort or otherwise, arising from,
+ *   out of or in connection with the Software or the use or other dealings in the
+ *   Software.
+ */
+
+package com.lielamar.auth.bukkit.utils.nayukifast;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+
+// Computes Reed-Solomon error correction codewords for given data codewords.
+final class ReedSolomonGenerator {
+	
+	// Use this memoizer to get instances of this class.
+	public static final Memoizer<Integer,ReedSolomonGenerator> MEMOIZER
+		= new Memoizer<>(ReedSolomonGenerator::new);
+	
+	
+	// A table of size 256 * degree, where polynomialMultiply[i][j] = multiply(i, coefficients[j]).
+	// 'coefficients' is the temporary array computed in the constructor.
+	private byte[][] polynomialMultiply;
+	
+	
+	// Creates a Reed-Solomon ECC generator polynomial for the given degree.
+	private ReedSolomonGenerator(int degree) {
+		if (degree < 1 || degree > 255)
+			throw new IllegalArgumentException("Degree out of range");
+		
+		// The divisor polynomial, whose coefficients are stored from highest to lowest power.
+		// For example, x^3 + 255x^2 + 8x + 93 is stored as the uint8 array {255, 8, 93}.
+		byte[] coefficients = new byte[degree];
+		coefficients[degree - 1] = 1;  // Start off with the monomial x^0
+		
+		// Compute the product polynomial (x - r^0) * (x - r^1) * (x - r^2) * ... * (x - r^{degree-1}),
+		// and drop the highest monomial term which is always 1x^degree.
+		// Note that r = 0x02, which is a generator element of this field GF(2^8/0x11D).
+		int root = 1;
+		for (int i = 0; i < degree; i++) {
+			// Multiply the current product by (x - r^i)
+			for (int j = 0; j < coefficients.length; j++) {
+				coefficients[j] = (byte)multiply(coefficients[j] & 0xFF, root);
+				if (j + 1 < coefficients.length)
+					coefficients[j] ^= coefficients[j + 1];
+			}
+			root = multiply(root, 0x02);
+		}
+		
+		polynomialMultiply = new byte[256][degree];
+		for (int i = 0; i < polynomialMultiply.length; i++) {
+			for (int j = 0; j < degree; j++)
+				polynomialMultiply[i][j] = (byte)multiply(i, coefficients[j] & 0xFF);
+		}
+	}
+	
+	
+	// Returns the error correction codeword for the given data polynomial and this divisor polynomial.
+	public void getRemainder(byte[] data, int dataOff, int dataLen, byte[] result) {
+		Objects.requireNonNull(data);
+		Objects.requireNonNull(result);
+		int degree = polynomialMultiply[0].length;
+		assert result.length == degree;
+		
+		Arrays.fill(result, (byte)0);
+		for (int i = dataOff, dataEnd = dataOff + dataLen; i < dataEnd; i++) {  // Polynomial division
+			byte[] table = polynomialMultiply[(data[i] ^ result[0]) & 0xFF];
+			for (int j = 0; j < degree - 1; j++)
+				result[j] = (byte)(result[j + 1] ^ table[j]);
+			result[degree - 1] = table[degree - 1];
+		}
+	}
+	
+	
+	// Returns the product of the two given field elements modulo GF(2^8/0x11D). The arguments and result
+	// are unsigned 8-bit integers. This could be implemented as a lookup table of 256*256 entries of uint8.
+	private static int multiply(int x, int y) {
+		assert x >> 8 == 0 && y >> 8 == 0;
+		// Russian peasant multiplication
+		int z = 0;
+		for (int i = 7; i >= 0; i--) {
+			z = (z << 1) ^ ((z >>> 7) * 0x11D);
+			z ^= ((y >>> i) & 1) * x;
+		}
+		assert z >>> 8 == 0;
+		return z;
+	}
+	
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/package-info.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/nayukifast/package-info.java
@@ -1,0 +1,52 @@
+/**
+ * Generates QR Codes from text strings and byte arrays.
+ * 
+ * <p>This project aims to be the best, clearest QR Code generator library. The primary goals are flexible options and absolute correctness. Secondary goals are compact implementation size and good documentation comments.</p>
+ * <p>Home page for this fast library with design explanation and benchmarks: <a href="https://www.nayuki.io/page/fast-qr-code-generator-library">https://www.nayuki.io/page/fast-qr-code-generator-library</a></p>
+ * <p>Home page for the main project with live JavaScript demo, extensive descriptions, and competitor comparisons: <a href="https://www.nayuki.io/page/qr-code-generator-library">https://www.nayuki.io/page/qr-code-generator-library</a></p>
+ * 
+ * <h2>Features</h2>
+ * <p>Core features:</p>
+ * <ul>
+ *   <li><p>Approximately 1.5× to 10× faster than other Java implementation</p></li>
+ *   <li><p>Shorter code but more documentation comments compared to competing libraries</p></li>
+ *   <li><p>Supports encoding all 40 versions (sizes) and all 4 error correction levels, as per the QR Code Model 2 standard</p></li>
+ *   <li><p>Output format: Raw modules/pixels of the QR symbol</p></li>
+ *   <li><p>Detects finder-like penalty patterns more accurately than other implementations</p></li>
+ *   <li><p>Encodes numeric and special-alphanumeric text in less space than general text</p></li>
+ *   <li><p>Encodes Japanese Unicode text in kanji mode to save a lot of space compared to UTF-8 bytes</p></li>
+ *   <li><p>Computes optimal segment mode switching for text with mixed numeric/alphanumeric/general/kanji parts</p></li>
+ *   <li><p>Open-source code under the permissive MIT License</p></li>
+ * </ul>
+ * <p>Manual parameters:</p>
+ * <ul>
+ *   <li><p>User can specify minimum and maximum version numbers allowed, then library will automatically choose smallest version in the range that fits the data</p></li>
+ *   <li><p>User can specify mask pattern manually, otherwise library will automatically evaluate all 8 masks and select the optimal one</p></li>
+ *   <li><p>User can specify absolute error correction level, or allow the library to boost it if it doesn't increase the version number</p></li>
+ *   <li><p>User can create a list of data segments manually and add ECI segments</p></li>
+ * </ul>
+ * <p>More information about QR Code technology and this library's design can be found on the project home page.</p>
+ * 
+ * <h2>Examples</h2>
+ * <p>Simple operation:</p>
+ * <pre style="margin-left:2em">import java.awt.image.BufferedImage;
+ *import java.io.File;
+ *import javax.imageio.ImageIO;
+ *import io.nayuki.fastqrcodegen.*;
+ *
+ *QrCode qr = QrCode.encodeText("Hello, world!", QrCode.Ecc.MEDIUM);
+ *BufferedImage img = toImage(qr, 4, 10);  // See QrCodeGeneratorDemo
+ *ImageIO.write(img, "png", new File("qr-code.png"));</pre>
+ * <p>Manual operation:</p>
+ * <pre style="margin-left:2em">import java.util.List;
+ *import io.nayuki.fastqrcodegen.*;
+ *
+ *List&lt;QrSegment&gt; segs = QrSegment.makeSegments("3141592653589793238462643383");
+ *QrCode qr = QrCode.encodeSegments(segs, QrCode.Ecc.HIGH, 5, 5, 2, false);
+ *for (int y = 0; y &lt; qr.size; y++) {
+ *    for (int x = 0; x &lt; qr.size; x++) {
+ *        (... paint qr.getModule(x, y) ...)
+ *    }
+ *}</pre>
+ */
+package com.lielamar.auth.bukkit.utils.nayukifast;

--- a/src/main/java/com/lielamar/auth/bukkit/utils/update/SpigotUpdateChecker.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/update/SpigotUpdateChecker.java
@@ -1,0 +1,82 @@
+package com.lielamar.auth.bukkit.utils.update;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+public class SpigotUpdateChecker implements Listener {
+
+    private static final String UPDATE_MSG = ChatColor.translateAlternateColorCodes('&', "&b&l%s &rhas an update available on &eSpigot&r!" + "\n&rYour version, &ev%s, &ris &e%s &rversions behind!");
+    private static final String SPIGOT_API = "https://api.spigotmc.org/legacy/update.php?resource=%s&t=%s";
+
+    private final JavaPlugin plugin;
+    private final int resourceId;
+    private final String updateMessage;
+    private final String currentVersion;
+    private String spigotVersion;
+
+
+    private int versionsBehind;
+
+    public SpigotUpdateChecker(JavaPlugin plugin, int resourceId) {
+        this(plugin, resourceId, UPDATE_MSG);
+    }
+
+    public SpigotUpdateChecker(JavaPlugin plugin, int resourceId, String updateMessage) {
+        this.plugin = plugin;
+        this.resourceId = resourceId;
+        this.updateMessage = updateMessage;
+        this.currentVersion = plugin.getDescription().getVersion();
+    }
+
+    public void checkForUpdates() {
+        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+            try {
+                HttpsURLConnection connection = (HttpsURLConnection) new URL(String.format(SPIGOT_API, resourceId, "-1")).openConnection();
+                connection.setRequestMethod("GET");
+                spigotVersion = new BufferedReader(new InputStreamReader(connection.getInputStream())).readLine();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return;
+            }
+
+            if(currentVersion.equals(spigotVersion)) return;
+
+            versionsBehind = 0;
+            versionsBehind += Integer.parseInt(spigotVersion.split("\\.")[1])-Integer.parseInt(currentVersion.split("\\.")[1]);
+            if(versionsBehind == 0)
+                versionsBehind += Integer.parseInt(spigotVersion.split("\\.")[2])-Integer.parseInt(currentVersion.split("\\.")[2]);
+
+            if(versionsBehind < 0) return;
+
+            sendUpdateMessage(Bukkit.getServer().getConsoleSender());
+
+            for(Player pl : Bukkit.getOnlinePlayers())
+                sendUpdateMessage(pl);
+
+            Bukkit.getPluginManager().registerEvents(new Listener() {
+                @EventHandler (priority = EventPriority.MONITOR)
+                public void onPlayerJoin(PlayerJoinEvent event) {
+                    sendUpdateMessage(event.getPlayer());
+                }
+            }, plugin);
+        });
+    }
+
+    public void sendUpdateMessage(CommandSender cs) {
+        if(cs.isOp())
+            cs.sendMessage(String.format(this.updateMessage, plugin.getName(), currentVersion, versionsBehind));
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/uuid/InvalidResponseException.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/uuid/InvalidResponseException.java
@@ -1,0 +1,10 @@
+package com.lielamar.auth.bukkit.utils.uuid;
+
+import org.jetbrains.annotations.NotNull;
+
+public class InvalidResponseException extends Exception {
+
+    public InvalidResponseException(@NotNull String explanation) {
+        super(explanation);
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDCallback.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDCallback.java
@@ -1,0 +1,11 @@
+package com.lielamar.auth.bukkit.utils.uuid;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+
+public interface UUIDCallback {
+
+    void run(@Nullable UUID uuid);
+
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDNotFoundException.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lielamar.auth.bukkit.utils.uuid;
+
+import org.jetbrains.annotations.NotNull;
+
+public class UUIDNotFoundException extends Exception {
+
+    public UUIDNotFoundException(@NotNull String explanation) {
+        super(explanation);
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDUtils.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/uuid/UUIDUtils.java
@@ -1,0 +1,98 @@
+package com.lielamar.auth.bukkit.utils.uuid;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.lielamar.auth.bukkit.utils.fetching.FetchingUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class UUIDUtils {
+
+    public static final long STARTUP_TIMESTAMP = System.currentTimeMillis();
+    private static final Type gsonType = new TypeToken<Map<String, String>>() {}.getType();
+
+    /**
+     * Generates a UUID based on current timestamp & startup time
+     *
+     * @return   Generated time-based uuid
+     */
+    public static @NotNull UUID generateTimeBasedUUID() { return generateTimeBasedUUID(STARTUP_TIMESTAMP); }
+    public static @NotNull UUID generateTimeBasedUUID(long timestamp) { return new UUID(System.currentTimeMillis(), timestamp); }
+
+
+    /**
+     * Fetches a Minecraft user's UUID from Mojang's API
+     *
+     * @param username                    Username of the Minecraft user
+     * @param callback                    Callback to call when a response is received
+     * @throws InvalidResponseException   Throws an exception if the given response was invalid
+     */
+    public static void fetchUUIDFromMojang(@NotNull String username, @NotNull UUIDCallback callback) throws InvalidResponseException {
+        OfflinePlayer offlinePlayer = Bukkit.getPlayer(username);
+
+        if(offlinePlayer != null)
+            callback.run(offlinePlayer.getUniqueId());
+        else {
+            FetchingUtils.fetch(String.format("https://api.mojang.com/users/profiles/minecraft/%s", username), (response) -> {
+                Map<String, String> res = new Gson().fromJson(response, gsonType);
+
+                String uuid = res.getOrDefault("id", null);
+                callback.run(uuid == null ? null : UUID.fromString(uuid));
+            });
+        }
+    }
+
+    /**
+     * Fetches a Minecraft user's UUID from Mojang's API
+     *
+     * @param username   Username of the Minecraft user
+     * @return           A CompletableFuture object of the user's uuid
+     */
+    public static @NotNull CompletableFuture<UUID> fetchUUIDFromMojang(@NotNull String username) {
+        OfflinePlayer offlinePlayer = Bukkit.getPlayer(username);
+
+        if(offlinePlayer != null)
+            return CompletableFuture.supplyAsync(offlinePlayer::getUniqueId);
+
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                String response = FetchingUtils.fetch(String.format("https://api.mojang.com/users/profiles/minecraft/%s", username));
+
+                try {
+                    Map<String, String> res = new Gson().fromJson(response, gsonType);
+                    String uuid = res.getOrDefault("id", null);
+                    if(uuid == null) {
+                        throw new CompletionException(new UUIDNotFoundException("UUID for username " + username + " was not found!"));
+                    }
+
+                    return UUID.fromString(fixUUID(uuid));
+                } catch (Exception exception) {
+                    throw new CompletionException(new UUIDNotFoundException("UUID for username " + username + " was not found!"));
+                }
+            } catch (InvalidResponseException exception) {
+                exception.printStackTrace();
+                throw new CompletionException(exception);
+            }
+        });
+    }
+
+    /**
+     * Fixes a uuid (adds dashes)
+     *
+     * @param uuid   UUID to fix
+     * @return       Fixed uuid
+     */
+    public static @NotNull String fixUUID(@NotNull String uuid) {
+        if(uuid.contains("-"))
+            return uuid;
+
+        return uuid.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)", "$1-$2-$3-$4-$5");
+    }
+}

--- a/src/main/java/com/lielamar/auth/bukkit/utils/version/Version.java
+++ b/src/main/java/com/lielamar/auth/bukkit/utils/version/Version.java
@@ -1,0 +1,110 @@
+package com.lielamar.auth.bukkit.utils.version;
+
+import org.bukkit.Bukkit;
+
+public class Version {
+
+    private static final Version instance = new Version();
+    public static Version getInstance() { return instance; }
+
+    private Version() {
+        try {
+            this.serverVersion = ServerVersion.valueOf("v" + Bukkit.getServer().getBukkitVersion().split("-")[0].replaceAll("\\.", "_"));
+        } catch (Exception ignored) {}
+    }
+
+
+    private ServerVersion serverVersion;
+
+    public ServerVersion getServerVersion() { return this.serverVersion; }
+
+
+    public enum ServerVersion {
+        v1_7_2("v1_7_2", 10702),
+        v1_7_5("v1_7_5", 10705),
+        v1_7_8("v1_7_8", 10708),
+        v1_7_9("v1_7_9", 10709),
+        v1_7_10("v1_7_10", 10710),
+
+        v1_8_0("v1_8_0", 10800),
+        v1_8_3("v1_8_3", 10803),
+        v1_8_4("v1_8_4", 10804),
+        v1_8_5("v1_8_5", 10805),
+        v1_8_6("v1_8_6", 10806),
+        v1_8_7("v1_8_7", 10807),
+        v1_8_8("v1_8_8", 10808),
+
+        v1_9_0("v1_9_0", 10900),
+        v1_9_2("v1_9_2", 10902),
+        v1_9_4("v1_9_4", 10904),
+
+        v1_10_0("v1_10_0", 11000),
+        v1_10_2("v1_10_2", 11002),
+
+        v1_11_0("v1_11_0", 11100),
+        v1_11_1("v1_11_1", 11101),
+        v1_11_2("v1_11_2", 11102),
+
+        v1_12_0("v1_12_0", 11200),
+        v1_12_1("v1_12_1", 11201),
+        v1_12_2("v1_12_2", 11202),
+
+        v1_13_0("v1_13_0", 11300),
+        v1_13_1("v1_13_1", 11301),
+        v1_13_2("v1_13_2", 11302),
+
+        v1_14_0("v1_14_0", 11400),
+        v1_14_1("v1_14_1", 11401),
+        v1_14_2("v1_14_2", 11402),
+        v1_14_3("v1_14_3", 11403),
+        v1_14_4("v1_14_4", 11404),
+
+        v1_15_0("v1_15_0", 11500),
+        v1_15_1("v1_15_1", 11501),
+        v1_15_2("v1_15_2", 11502),
+
+        v1_16_1("v1_16_1", 11601),
+        v1_16_2("v1_16_2", 11602),
+        v1_16_3("v1_16_3", 11603),
+        v1_16_4("v1_16_4", 11604),
+        v1_16_5("v1_16_5", 11605),
+
+        v1_17_0("v1_17_0", 11700),
+        v1_17_1("v1_17_1", 11701),
+
+        v1_18_0("v1_18_0", 11800),
+        v1_18_1("v1_18_1", 11801),
+        v1_18_2("v1_18_2", 11802),
+
+        v1_19_0("v1_19_0", 11900),
+        v1_19_1("v1_19_1", 11901),
+        v1_19_2("v1_19_2", 11902),
+        v1_19_3("v1_19_3", 11903),
+        v1_19_4("v1_19_4", 11904),
+
+        v1_20_0("v1_20_0", 12000),
+        v1_20_1("v1_20_1", 12001),
+        v1_20_2("v1_20_2", 12002),
+        v1_20_3("v1_20_3", 12003),
+        v1_20_4("v1_20_4", 12004),
+        v1_20_5("v1_20_5", 12005),
+        v1_20_6("v1_20_6", 12006),
+
+        v1_21_0("v1_21_0", 12101);
+
+        private final String versionName;
+        private final int versionId;
+
+        ServerVersion(String versionName, int versionId) {
+            this.versionName = versionName;
+            this.versionId = versionId;
+        }
+
+        public String getVersionName() { return this.versionName; }
+        public String getStrippedName() { return this.versionName.replaceFirst("v", "").replaceAll("_", "."); }
+
+        int getVersionId() { return this.versionId; }
+
+        public boolean above(ServerVersion otherVersion) { return this.versionId >= otherVersion.getVersionId(); }
+    }
+}

--- a/src/main/java/com/lielamar/auth/bungee/TwoFactorAuthentication.java
+++ b/src/main/java/com/lielamar/auth/bungee/TwoFactorAuthentication.java
@@ -1,16 +1,16 @@
 package com.lielamar.auth.bungee;
 
-import com.lielamar.auth.bungee.listeners.OnAuthStateChange;
-import com.lielamar.auth.shared.TwoFactorAuthenticationPlugin;
-import com.lielamar.auth.shared.utils.AuthTracker;
 import com.lielamar.auth.bungee.handlers.AuthHandler;
 import com.lielamar.auth.bungee.handlers.ConfigHandler;
 import com.lielamar.auth.bungee.handlers.MessageHandler;
 import com.lielamar.auth.bungee.listeners.DisabledEvents;
+import com.lielamar.auth.bungee.listeners.OnAuthStateChange;
 import com.lielamar.auth.bungee.listeners.OnBungeePlayerConnections;
 import com.lielamar.auth.bungee.listeners.OnPluginMessage;
+import com.lielamar.auth.bungee.utils.BungeeMetrics;
+import com.lielamar.auth.shared.TwoFactorAuthenticationPlugin;
 import com.lielamar.auth.shared.handlers.PluginMessagingHandler;
-import com.lielamar.lielsutils.bukkit.bstats.BungeeMetrics;
+import com.lielamar.auth.shared.utils.AuthTracker;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 

--- a/src/main/java/com/lielamar/auth/bungee/handlers/MessageHandler.java
+++ b/src/main/java/com/lielamar/auth/bungee/handlers/MessageHandler.java
@@ -1,7 +1,7 @@
 package com.lielamar.auth.bungee.handlers;
 
+import com.lielamar.auth.shared.utils.color.ColorUtils;
 import com.lielamar.auth.bungee.TwoFactorAuthentication;
-import com.lielamar.lielsutils.bukkit.color.ColorUtils;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;

--- a/src/main/java/com/lielamar/auth/bungee/listeners/OnAuthStateChange.java
+++ b/src/main/java/com/lielamar/auth/bungee/listeners/OnAuthStateChange.java
@@ -18,7 +18,7 @@ public class OnAuthStateChange implements Listener {
     @EventHandler
     public void onStateChange(PlayerStateChangeEvent event) {
         if (event.getNewAuthState().equals(AuthHandler.AuthState.AUTHENTICATED)) {
-            this.plugin.getAuthTracker().setAuthentications(this.plugin.getAuthTracker().getAuthentications() + 1);
+            this.plugin.getAuthTracker().incrementAuths();
         }
     }
 }

--- a/src/main/java/com/lielamar/auth/bungee/utils/BungeeMetrics.java
+++ b/src/main/java/com/lielamar/auth/bungee/utils/BungeeMetrics.java
@@ -1,0 +1,860 @@
+package com.lielamar.auth.bungee.utils;/*
+ * This Metrics class was auto-generated and can be copied into your project if you are
+ * not using a build tool like Gradle or Maven for dependency management.
+ *
+ * IMPORTANT: You are not allowed to modify this class, except changing the package.
+ *
+ * Unallowed modifications include but are not limited to:
+ *  - Remove the option for users to opt-out
+ *  - Change the frequency for data submission
+ *  - Obfuscate the code (every obfucator should allow you to make an exception for specific files)
+ *  - Reformat the code (if you use a linter, add an exception)
+ *
+ * Violations will result in a ban of your plugin and account from bStats.
+ */
+
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.config.Configuration;
+import net.md_5.bungee.config.ConfigurationProvider;
+import net.md_5.bungee.config.YamlConfiguration;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.*;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPOutputStream;
+
+public class BungeeMetrics {
+
+    private final Plugin plugin;
+
+    private final MetricsBase metricsBase;
+
+    private boolean enabled;
+
+    private String serverUUID;
+
+    private boolean logErrors = false;
+
+    private boolean logSentData;
+
+    private boolean logResponseStatusText;
+
+    /**
+     * Creates a new Metrics instance.
+     *
+     * @param plugin Your plugin instance.
+     * @param serviceId The id of the service. It can be found at <a
+     *     href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
+     */
+    public BungeeMetrics(Plugin plugin, int serviceId) {
+        this.plugin = plugin;
+        try {
+            loadConfig();
+        } catch (IOException e) {
+            // Failed to load configuration
+            plugin.getLogger().log(Level.WARNING, "Failed to load bStats config!", e);
+            metricsBase = null;
+            return;
+        }
+        metricsBase =
+                new MetricsBase(
+                        "bungeecord",
+                        serverUUID,
+                        serviceId,
+                        enabled,
+                        this::appendPlatformData,
+                        this::appendServiceData,
+                        null,
+                        () -> true,
+                        (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
+                        (message) -> this.plugin.getLogger().log(Level.INFO, message),
+                        logErrors,
+                        logSentData,
+                        logResponseStatusText);
+    }
+
+    /** Loads the bStats configuration. */
+    private void loadConfig() throws IOException {
+        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+        bStatsFolder.mkdirs();
+        File configFile = new File(bStatsFolder, "config.yml");
+        if (!configFile.exists()) {
+            writeFile(
+                    configFile,
+                    "# bStats (https://bStats.org) collects some basic information for plugin authors, like how",
+                    "# many people use their plugin and their total player count. It's recommended to keep bStats",
+                    "# enabled, but if you're not comfortable with this, you can turn this setting off. There is no",
+                    "# performance penalty associated with having metrics enabled, and data sent to bStats is fully",
+                    "# anonymous.",
+                    "enabled: true",
+                    "serverUuid: \"" + UUID.randomUUID() + "\"",
+                    "logFailedRequests: false",
+                    "logSentData: false",
+                    "logResponseStatusText: false");
+        }
+        Configuration configuration =
+                ConfigurationProvider.getProvider(YamlConfiguration.class).load(configFile);
+        // Load configuration
+        enabled = configuration.getBoolean("enabled", true);
+        serverUUID = configuration.getString("serverUuid");
+        logErrors = configuration.getBoolean("logFailedRequests", false);
+        logSentData = configuration.getBoolean("logSentData", false);
+        logResponseStatusText = configuration.getBoolean("logResponseStatusText", false);
+    }
+
+    private void writeFile(File file, String... lines) throws IOException {
+        try (BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(file))) {
+            for (String line : lines) {
+                bufferedWriter.write(line);
+                bufferedWriter.newLine();
+            }
+        }
+    }
+
+    /**
+     * Adds a custom chart.
+     *
+     * @param chart The chart to add.
+     */
+    public void addCustomChart(CustomChart chart) {
+        metricsBase.addCustomChart(chart);
+    }
+
+    private void appendPlatformData(JsonObjectBuilder builder) {
+        builder.appendField("playerAmount", plugin.getProxy().getOnlineCount());
+        builder.appendField("managedServers", plugin.getProxy().getServers().size());
+        builder.appendField("onlineMode", plugin.getProxy().getConfig().isOnlineMode() ? 1 : 0);
+        builder.appendField("bungeecordVersion", plugin.getProxy().getVersion());
+        builder.appendField("javaVersion", System.getProperty("java.version"));
+        builder.appendField("osName", System.getProperty("os.name"));
+        builder.appendField("osArch", System.getProperty("os.arch"));
+        builder.appendField("osVersion", System.getProperty("os.version"));
+        builder.appendField("coreCount", Runtime.getRuntime().availableProcessors());
+    }
+
+    private void appendServiceData(JsonObjectBuilder builder) {
+        builder.appendField("pluginVersion", plugin.getDescription().getVersion());
+    }
+
+    public static class MetricsBase {
+
+        /** The version of the Metrics class. */
+        public static final String METRICS_VERSION = "3.0.0";
+
+        private static final ScheduledExecutorService scheduler =
+                Executors.newScheduledThreadPool(1, task -> new Thread(task, "bStats-Metrics"));
+
+        private static final String REPORT_URL = "https://bStats.org/api/v2/data/%s";
+
+        private final String platform;
+
+        private final String serverUuid;
+
+        private final int serviceId;
+
+        private final Consumer<JsonObjectBuilder> appendPlatformDataConsumer;
+
+        private final Consumer<JsonObjectBuilder> appendServiceDataConsumer;
+
+        private final Consumer<Runnable> submitTaskConsumer;
+
+        private final Supplier<Boolean> checkServiceEnabledSupplier;
+
+        private final BiConsumer<String, Throwable> errorLogger;
+
+        private final Consumer<String> infoLogger;
+
+        private final boolean logErrors;
+
+        private final boolean logSentData;
+
+        private final boolean logResponseStatusText;
+
+        private final Set<CustomChart> customCharts = new HashSet<>();
+
+        private final boolean enabled;
+
+        /**
+         * Creates a new MetricsBase class instance.
+         *
+         * @param platform The platform of the service.
+         * @param serviceId The id of the service.
+         * @param serverUuid The server uuid.
+         * @param enabled Whether or not data sending is enabled.
+         * @param appendPlatformDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+         *     appends all platform-specific data.
+         * @param appendServiceDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+         *     appends all service-specific data.
+         * @param submitTaskConsumer A consumer that takes a runnable with the submit task. This can be
+         *     used to delegate the data collection to a another thread to prevent errors caused by
+         *     concurrency. Can be {@code null}.
+         * @param checkServiceEnabledSupplier A supplier to check if the service is still enabled.
+         * @param errorLogger A consumer that accepts log message and an error.
+         * @param infoLogger A consumer that accepts info log messages.
+         * @param logErrors Whether or not errors should be logged.
+         * @param logSentData Whether or not the sent data should be logged.
+         * @param logResponseStatusText Whether or not the response status text should be logged.
+         */
+        public MetricsBase(
+                String platform,
+                String serverUuid,
+                int serviceId,
+                boolean enabled,
+                Consumer<JsonObjectBuilder> appendPlatformDataConsumer,
+                Consumer<JsonObjectBuilder> appendServiceDataConsumer,
+                Consumer<Runnable> submitTaskConsumer,
+                Supplier<Boolean> checkServiceEnabledSupplier,
+                BiConsumer<String, Throwable> errorLogger,
+                Consumer<String> infoLogger,
+                boolean logErrors,
+                boolean logSentData,
+                boolean logResponseStatusText) {
+            this.platform = platform;
+            this.serverUuid = serverUuid;
+            this.serviceId = serviceId;
+            this.enabled = enabled;
+            this.appendPlatformDataConsumer = appendPlatformDataConsumer;
+            this.appendServiceDataConsumer = appendServiceDataConsumer;
+            this.submitTaskConsumer = submitTaskConsumer;
+            this.checkServiceEnabledSupplier = checkServiceEnabledSupplier;
+            this.errorLogger = errorLogger;
+            this.infoLogger = infoLogger;
+            this.logErrors = logErrors;
+            this.logSentData = logSentData;
+            this.logResponseStatusText = logResponseStatusText;
+            checkRelocation();
+            if (enabled) {
+                // WARNING: Removing the option to opt-out will get your plugin banned from bStats
+                startSubmitting();
+            }
+        }
+
+        public void addCustomChart(CustomChart chart) {
+            this.customCharts.add(chart);
+        }
+
+        private void startSubmitting() {
+            final Runnable submitTask =
+                    () -> {
+                        if (!enabled || !checkServiceEnabledSupplier.get()) {
+                            // Submitting data or service is disabled
+                            scheduler.shutdown();
+                            return;
+                        }
+                        if (submitTaskConsumer != null) {
+                            submitTaskConsumer.accept(this::submitData);
+                        } else {
+                            this.submitData();
+                        }
+                    };
+            // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution
+            // of requests on the
+            // bStats backend. To circumvent this problem, we introduce some randomness into the initial
+            // and second delay.
+            // WARNING: You must not modify and part of this Metrics class, including the submit delay or
+            // frequency!
+            // WARNING: Modifying this code will get your plugin banned on bStats. Just don't do it!
+            long initialDelay = (long) (1000 * 60 * (3 + Math.random() * 3));
+            long secondDelay = (long) (1000 * 60 * (Math.random() * 30));
+            scheduler.schedule(submitTask, initialDelay, TimeUnit.MILLISECONDS);
+            scheduler.scheduleAtFixedRate(
+                    submitTask, initialDelay + secondDelay, 1000 * 60 * 30, TimeUnit.MILLISECONDS);
+        }
+
+        private void submitData() {
+            final JsonObjectBuilder baseJsonBuilder = new JsonObjectBuilder();
+            appendPlatformDataConsumer.accept(baseJsonBuilder);
+            final JsonObjectBuilder serviceJsonBuilder = new JsonObjectBuilder();
+            appendServiceDataConsumer.accept(serviceJsonBuilder);
+            JsonObjectBuilder.JsonObject[] chartData =
+                    customCharts.stream()
+                            .map(customChart -> customChart.getRequestJsonObject(errorLogger, logErrors))
+                            .filter(Objects::nonNull)
+                            .toArray(JsonObjectBuilder.JsonObject[]::new);
+            serviceJsonBuilder.appendField("id", serviceId);
+            serviceJsonBuilder.appendField("customCharts", chartData);
+            baseJsonBuilder.appendField("service", serviceJsonBuilder.build());
+            baseJsonBuilder.appendField("serverUUID", serverUuid);
+            baseJsonBuilder.appendField("metricsVersion", METRICS_VERSION);
+            JsonObjectBuilder.JsonObject data = baseJsonBuilder.build();
+            scheduler.execute(
+                    () -> {
+                        try {
+                            // Send the data
+                            sendData(data);
+                        } catch (Exception e) {
+                            // Something went wrong! :(
+                            if (logErrors) {
+                                errorLogger.accept("Could not submit bStats metrics data", e);
+                            }
+                        }
+                    });
+        }
+
+        private void sendData(JsonObjectBuilder.JsonObject data) throws Exception {
+            if (logSentData) {
+                infoLogger.accept("Sent bStats metrics data: " + data.toString());
+            }
+            String url = String.format(REPORT_URL, platform);
+            HttpsURLConnection connection = (HttpsURLConnection) new URL(url).openConnection();
+            // Compress the data to save bandwidth
+            byte[] compressedData = compress(data.toString());
+            connection.setRequestMethod("POST");
+            connection.addRequestProperty("Accept", "application/json");
+            connection.addRequestProperty("Connection", "close");
+            connection.addRequestProperty("Content-Encoding", "gzip");
+            connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("User-Agent", "Metrics-Service/1");
+            connection.setDoOutput(true);
+            try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+                outputStream.write(compressedData);
+            }
+            StringBuilder builder = new StringBuilder();
+            try (BufferedReader bufferedReader =
+                         new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    builder.append(line);
+                }
+            }
+            if (logResponseStatusText) {
+                infoLogger.accept("Sent data to bStats and received response: " + builder);
+            }
+        }
+
+        /** Checks that the class was properly relocated. */
+        private void checkRelocation() {
+            // You can use the property to disable the check in your test environment
+            if (System.getProperty("bstats.relocatecheck") == null
+                    || !System.getProperty("bstats.relocatecheck").equals("false")) {
+                // Maven's Relocate is clever and changes strings, too. So we have to use this little
+                // "trick" ... :D
+                final String defaultPackage =
+                        new String(new byte[] {'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
+                final String examplePackage =
+                        new String(new byte[] {'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
+                // We want to make sure no one just copy & pastes the example and uses the wrong package
+                // names
+                if (MetricsBase.class.getPackage().getName().startsWith(defaultPackage)
+                        || MetricsBase.class.getPackage().getName().startsWith(examplePackage)) {
+                    throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+                }
+            }
+        }
+
+        /**
+         * Gzips the given string.
+         *
+         * @param str The string to gzip.
+         * @return The gzipped string.
+         */
+        private static byte[] compress(final String str) throws IOException {
+            if (str == null) {
+                return null;
+            }
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+                gzip.write(str.getBytes(StandardCharsets.UTF_8));
+            }
+            return outputStream.toByteArray();
+        }
+    }
+
+    public static class DrilldownPie extends CustomChart {
+
+        private final Callable<Map<String, Map<String, Integer>>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        public JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Map<String, Integer>> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean reallyAllSkipped = true;
+            for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
+                JsonObjectBuilder valueBuilder = new JsonObjectBuilder();
+                boolean allSkipped = true;
+                for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
+                    valueBuilder.appendField(valueEntry.getKey(), valueEntry.getValue());
+                    allSkipped = false;
+                }
+                if (!allSkipped) {
+                    reallyAllSkipped = false;
+                    valuesBuilder.appendField(entryValues.getKey(), valueBuilder.build());
+                }
+            }
+            if (reallyAllSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class AdvancedPie extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class MultiLineChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                if (entry.getValue() == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class SimpleBarChart extends CustomChart {
+
+        private final Callable<Map<String, Integer>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, Integer> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            for (Map.Entry<String, Integer> entry : map.entrySet()) {
+                valuesBuilder.appendField(entry.getKey(), new int[] {entry.getValue()});
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public abstract static class CustomChart {
+
+        private final String chartId;
+
+        protected CustomChart(String chartId) {
+            if (chartId == null) {
+                throw new IllegalArgumentException("chartId must not be null");
+            }
+            this.chartId = chartId;
+        }
+
+        public JsonObjectBuilder.JsonObject getRequestJsonObject(
+                BiConsumer<String, Throwable> errorLogger, boolean logErrors) {
+            JsonObjectBuilder builder = new JsonObjectBuilder();
+            builder.appendField("chartId", chartId);
+            try {
+                JsonObjectBuilder.JsonObject data = getChartData();
+                if (data == null) {
+                    // If the data is null we don't send the chart.
+                    return null;
+                }
+                builder.appendField("data", data);
+            } catch (Throwable t) {
+                if (logErrors) {
+                    errorLogger.accept("Failed to get data for custom chart with id " + chartId, t);
+                }
+                return null;
+            }
+            return builder.build();
+        }
+
+        protected abstract JsonObjectBuilder.JsonObject getChartData() throws Exception;
+    }
+
+    public static class SimplePie extends CustomChart {
+
+        private final Callable<String> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SimplePie(String chartId, Callable<String> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            String value = callable.call();
+            if (value == null || value.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("value", value).build();
+        }
+    }
+
+    public static class AdvancedBarChart extends CustomChart {
+
+        private final Callable<Map<String, int[]>> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+            Map<String, int[]> map = callable.call();
+            if (map == null || map.isEmpty()) {
+                // Null = skip the chart
+                return null;
+            }
+            boolean allSkipped = true;
+            for (Map.Entry<String, int[]> entry : map.entrySet()) {
+                if (entry.getValue().length == 0) {
+                    // Skip this invalid
+                    continue;
+                }
+                allSkipped = false;
+                valuesBuilder.appendField(entry.getKey(), entry.getValue());
+            }
+            if (allSkipped) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+        }
+    }
+
+    public static class SingleLineChart extends CustomChart {
+
+        private final Callable<Integer> callable;
+
+        /**
+         * Class constructor.
+         *
+         * @param chartId The id of the chart.
+         * @param callable The callable which is used to request the chart data.
+         */
+        public SingleLineChart(String chartId, Callable<Integer> callable) {
+            super(chartId);
+            this.callable = callable;
+        }
+
+        @Override
+        protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+            int value = callable.call();
+            if (value == 0) {
+                // Null = skip the chart
+                return null;
+            }
+            return new JsonObjectBuilder().appendField("value", value).build();
+        }
+    }
+
+    /**
+     * An extremely simple JSON builder.
+     *
+     * <p>While this class is neither feature-rich nor the most performant one, it's sufficient enough
+     * for its use-case.
+     */
+    public static class JsonObjectBuilder {
+
+        private StringBuilder builder = new StringBuilder();
+
+        private boolean hasAtLeastOneField = false;
+
+        public JsonObjectBuilder() {
+            builder.append("{");
+        }
+
+        /**
+         * Appends a null field to the JSON.
+         *
+         * @param key The key of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendNull(String key) {
+            appendFieldUnescaped(key, "null");
+            return this;
+        }
+
+        /**
+         * Appends a string field to the JSON.
+         *
+         * @param key The key of the field.
+         * @param value The value of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, String value) {
+            if (value == null) {
+                throw new IllegalArgumentException("JSON value must not be null");
+            }
+            appendFieldUnescaped(key, "\"" + escape(value) + "\"");
+            return this;
+        }
+
+        /**
+         * Appends an integer field to the JSON.
+         *
+         * @param key The key of the field.
+         * @param value The value of the field.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, int value) {
+            appendFieldUnescaped(key, String.valueOf(value));
+            return this;
+        }
+
+        /**
+         * Appends an object to the JSON.
+         *
+         * @param key The key of the field.
+         * @param object The object.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, JsonObject object) {
+            if (object == null) {
+                throw new IllegalArgumentException("JSON object must not be null");
+            }
+            appendFieldUnescaped(key, object.toString());
+            return this;
+        }
+
+        /**
+         * Appends a string array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The string array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, String[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values)
+                            .map(value -> "\"" + escape(value) + "\"")
+                            .collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends an integer array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The integer array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, int[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values).mapToObj(String::valueOf).collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends an object array to the JSON.
+         *
+         * @param key The key of the field.
+         * @param values The integer array.
+         * @return A reference to this object.
+         */
+        public JsonObjectBuilder appendField(String key, JsonObject[] values) {
+            if (values == null) {
+                throw new IllegalArgumentException("JSON values must not be null");
+            }
+            String escapedValues =
+                    Arrays.stream(values).map(JsonObject::toString).collect(Collectors.joining(","));
+            appendFieldUnescaped(key, "[" + escapedValues + "]");
+            return this;
+        }
+
+        /**
+         * Appends a field to the object.
+         *
+         * @param key The key of the field.
+         * @param escapedValue The escaped value of the field.
+         */
+        private void appendFieldUnescaped(String key, String escapedValue) {
+            if (builder == null) {
+                throw new IllegalStateException("JSON has already been built");
+            }
+            if (key == null) {
+                throw new IllegalArgumentException("JSON key must not be null");
+            }
+            if (hasAtLeastOneField) {
+                builder.append(",");
+            }
+            builder.append("\"").append(escape(key)).append("\":").append(escapedValue);
+            hasAtLeastOneField = true;
+        }
+
+        /**
+         * Builds the JSON string and invalidates this builder.
+         *
+         * @return The built JSON string.
+         */
+        public JsonObject build() {
+            if (builder == null) {
+                throw new IllegalStateException("JSON has already been built");
+            }
+            JsonObject object = new JsonObject(builder.append("}").toString());
+            builder = null;
+            return object;
+        }
+
+        /**
+         * Escapes the given string like stated in https://www.ietf.org/rfc/rfc4627.txt.
+         *
+         * <p>This method escapes only the necessary characters '"', '\'. and '\u0000' - '\u001F'.
+         * Compact escapes are not used (e.g., '\n' is escaped as "\u000a" and not as "\n").
+         *
+         * @param value The value to escape.
+         * @return The escaped value.
+         */
+        private static String escape(String value) {
+            final StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                if (c == '"') {
+                    builder.append("\\\"");
+                } else if (c == '\\') {
+                    builder.append("\\\\");
+                } else if (c <= '\u000F') {
+                    builder.append("\\u000").append(Integer.toHexString(c));
+                } else if (c <= '\u001F') {
+                    builder.append("\\u00").append(Integer.toHexString(c));
+                } else {
+                    builder.append(c);
+                }
+            }
+            return builder.toString();
+        }
+
+        /**
+         * A super simple representation of a JSON object.
+         *
+         * <p>This class only exists to make methods of the {@link JsonObjectBuilder} type-safe and not
+         * allow a raw string inputs for methods like {@link JsonObjectBuilder#appendField(String,
+         * JsonObject)}.
+         */
+        public static class JsonObject {
+
+            private final String value;
+
+            private JsonObject(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+    }
+}

--- a/src/main/java/com/lielamar/auth/shared/communication/AuthCommunicationHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/communication/AuthCommunicationHandler.java
@@ -54,8 +54,7 @@ public abstract class AuthCommunicationHandler {
         }
     }
 
-    protected @NotNull
-    UUID registerCallback(@Nullable AuthCommunicationCallback callback) {
+    protected @NotNull UUID registerCallback(@Nullable AuthCommunicationCallback callback) {
         UUID randomUUID = UUID.randomUUID();
 
         if (callback != null) {

--- a/src/main/java/com/lielamar/auth/shared/handlers/AuthHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/handlers/AuthHandler.java
@@ -1,9 +1,12 @@
 package com.lielamar.auth.shared.handlers;
 
+import com.atlassian.onetime.core.TOTP;
+import com.atlassian.onetime.model.TOTPSecret;
+import com.atlassian.onetime.service.DefaultTOTPService;
+import com.atlassian.onetime.service.RandomSecretProvider;
+import com.atlassian.onetime.service.SecretProvider;
 import com.lielamar.auth.shared.communication.AuthCommunicationHandler;
 import com.lielamar.auth.shared.storage.StorageHandler;
-import com.warrenstrange.googleauth.GoogleAuthenticator;
-import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -20,6 +23,9 @@ public abstract class AuthHandler {
     protected AuthCommunicationHandler authCommunicationHandler, fallbackCommunicationHandler;
     protected HashMap<UUID, AuthState> authStates;
 
+    private final DefaultTOTPService totpService;
+    private final SecretProvider secretProvider;
+
     public AuthHandler() {
         this(null, null);
     }
@@ -32,6 +38,8 @@ public abstract class AuthHandler {
             @Nullable AuthCommunicationHandler fallbackCommunicationHandler) {
         this.pendingKeys = new HashMap<>();
         this.failedAttempts = new HashMap<>();
+        this.secretProvider = new RandomSecretProvider();
+        this.totpService = new DefaultTOTPService();
 
         this.storageHandler = storageHandler;
         this.authCommunicationHandler = authCommunicationHandler;
@@ -127,12 +135,11 @@ public abstract class AuthHandler {
      * @return Created Key
      */
     public @NotNull String createKey(@NotNull UUID uuid) {
-        GoogleAuthenticator authenticator = new GoogleAuthenticator();
-        GoogleAuthenticatorKey key = authenticator.createCredentials();
+        TOTPSecret key = secretProvider.generateSecret();
 
         this.changeState(uuid, AuthState.PENDING_SETUP);
-        this.pendingKeys.put(uuid, key.getKey());
-        return key.getKey();
+        this.pendingKeys.put(uuid, key.getBase32Encoded());
+        return key.getBase32Encoded();
     }
 
     /**
@@ -140,12 +147,13 @@ public abstract class AuthHandler {
      *
      * @param uuid UUID of the player to validate the key of
      * @param code Inserted code
-     * @return Whether or not the code is valid
+     * @return Whether the code is valid
      */
-    public boolean validateKey(@NotNull UUID uuid, @NotNull Integer code) {
-        String key = this.getKey(uuid);
+    public boolean validateKey(@NotNull UUID uuid, @NotNull String code) {
+        String base32Key = this.getKey(uuid);
 
-        if (key != null && new GoogleAuthenticator().authorize(key, code) && this.authStates.get(uuid).equals(AuthState.PENDING_LOGIN)) {
+        if (base32Key != null && totpService.verify(new TOTP(code), TOTPSecret.Companion.fromBase32EncodedString(base32Key)).isSuccess()
+                && this.authStates.get(uuid).equals(AuthState.PENDING_LOGIN)) {
             this.changeState(uuid, AuthState.AUTHENTICATED);
             return true;
         }
@@ -158,20 +166,20 @@ public abstract class AuthHandler {
      *
      * @param uuid UUID of the player to validate the key of
      * @param code Inserted code
-     * @return Whether or not the code is valid
+     * @return Whether the code is valid
      */
-    public boolean approveKey(@NotNull UUID uuid, @NotNull Integer code) {
+    public boolean approveKey(@NotNull UUID uuid, @NotNull String code) {
         if (this.getStorageHandler() == null) {
             return false;
         }
 
-        String key = this.getPendingKey(uuid);
+        String base32Key = this.getPendingKey(uuid);
 
-        if (key != null && new GoogleAuthenticator().authorize(key, code)
+        if (base32Key != null && totpService.verify(new TOTP(code), TOTPSecret.Companion.fromBase32EncodedString(base32Key)).isSuccess()
                 && (this.authStates.get(uuid).equals(AuthState.PENDING_SETUP) || this.authStates.get(uuid).equals(AuthState.DEMAND_SETUP))) {
             this.changeState(uuid, AuthState.AUTHENTICATED);
 
-            this.getStorageHandler().setKey(uuid, key);
+            this.getStorageHandler().setKey(uuid, base32Key);
             this.getStorageHandler().setEnableDate(uuid, System.currentTimeMillis());
             this.pendingKeys.remove(uuid);
 

--- a/src/main/java/com/lielamar/auth/shared/handlers/AuthHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/handlers/AuthHandler.java
@@ -23,8 +23,8 @@ public abstract class AuthHandler {
     protected AuthCommunicationHandler authCommunicationHandler, fallbackCommunicationHandler;
     protected HashMap<UUID, AuthState> authStates;
 
-    private final DefaultTOTPService totpService;
-    private final SecretProvider secretProvider;
+    protected final DefaultTOTPService totpService;
+    protected final SecretProvider secretProvider;
 
     public AuthHandler() {
         this(null, null);

--- a/src/main/java/com/lielamar/auth/shared/handlers/MessageHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/handlers/MessageHandler.java
@@ -1,6 +1,6 @@
 package com.lielamar.auth.shared.handlers;
 
-import com.lielamar.lielsutils.groups.Pair;
+import com.lielamar.auth.shared.utils.groups.Pair;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class MessageHandler {
@@ -23,7 +23,7 @@ public abstract class MessageHandler {
         String raw = message.getMessage();
         String rawPrefix = TwoFAMessages.PREFIX.getMessage();
 
-        if (raw != null && raw.length() > 0) {
+        if (raw != null && !raw.isEmpty()) {
             for (Pair<?, ?> pair : args) {
                 raw = raw.replaceAll(pair.getA().toString(), pair.getB().toString());
             }
@@ -82,7 +82,7 @@ public abstract class MessageHandler {
         KEYWORD_REQUIRED("Required"),
         KEYWORD_NOT_REQUIRED("Not Required"),
         HELP_HEADER("&7----- &b2FA &7-----"),
-        HELP_COMMAND("&7\u2022 &b%command% &e%aliases%&7: %description%"),
+        HELP_COMMAND("&7• &b%command% &e%aliases%&7: %description%"),
         HELP_FOOTER("&7----- -------- -----"),
         DESCRIPTION_OF_DISABLE_COMMAND("Disables 2FA"),
         DESCRIPTION_OF_DISABLE_OTHERS_COMMAND("Disable 2FA for other users"),

--- a/src/main/java/com/lielamar/auth/shared/storage/StorageHandler.java
+++ b/src/main/java/com/lielamar/auth/shared/storage/StorageHandler.java
@@ -114,34 +114,25 @@ public abstract class StorageHandler {
     public static StorageHandler loadStorageHandler(ConfigHandler configHandler, String absolutePath) {
         try {
             isLoaded = true;
-            switch (configHandler.getStorageMethod()) {
-                case MYSQL:
-                    return new SQLStorage("com.mysql.cj.jdbc.MysqlDataSource",
-                            configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
-                            configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
-
-                case H2:
-                    return new SQLStorage("org.h2.jdbcx.JdbcDataSource",
-                            configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
-                            configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
-
-                case MARIADB:
-                    return new SQLStorage("org.mariadb.jdbc.MariaDbDataSource",
-                            configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
-                            configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
-
-                case POSTGRESQL:
-                    return new SQLStorage("org.postgresql.ds.PGSimpleDataSource",
-                            configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
-                            configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
-
-                case MONGODB:
-                    return new MongoDBStorage(configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
-                            configHandler.getCollectionPrefix(), configHandler.getMongodbURI());
-
-                default: // JSON
-                    return new JSONStorage(absolutePath);
-            }
+            return switch (configHandler.getStorageMethod()) {
+                case MYSQL -> new SQLStorage("com.mysql.cj.jdbc.MysqlDataSource",
+                        configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
+                        configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
+                case H2 -> new SQLStorage("org.h2.jdbcx.JdbcDataSource",
+                        configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
+                        configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
+                case MARIADB -> new SQLStorage("org.mariadb.jdbc.MariaDbDataSource",
+                        configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
+                        configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
+                case POSTGRESQL -> new SQLStorage("org.postgresql.ds.PGSimpleDataSource",
+                        configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
+                        configHandler.getTablePrefix(), configHandler.getMaximumPoolSize(), configHandler.getMinimumIdle(), configHandler.getMaximumLifetime(), configHandler.getKeepAliveTime(), configHandler.getConnectionTimeout());
+                case MONGODB ->
+                        new MongoDBStorage(configHandler.getHost(), configHandler.getDatabase(), configHandler.getUsername(), configHandler.getPassword(), configHandler.getPort(),
+                                configHandler.getCollectionPrefix(), configHandler.getMongodbURI());
+                default -> // JSON
+                        new JSONStorage(absolutePath);
+            };
         } catch (Exception exception) {
             isLoaded = false;
             exception.printStackTrace();

--- a/src/main/java/com/lielamar/auth/shared/utils/AuthTracker.java
+++ b/src/main/java/com/lielamar/auth/shared/utils/AuthTracker.java
@@ -15,4 +15,8 @@ public class AuthTracker {
     public void setAuthentications(int authentications) {
         this.authentications = authentications;
     }
+
+    public int incrementAuths() {
+        return ++authentications;
+    }
 }

--- a/src/main/java/com/lielamar/auth/shared/utils/Constants.java
+++ b/src/main/java/com/lielamar/auth/shared/utils/Constants.java
@@ -1,6 +1,6 @@
 package com.lielamar.auth.shared.utils;
 
-import com.lielamar.lielsutils.groups.Pair;
+import com.lielamar.auth.shared.utils.groups.Pair;
 
 public class Constants {
 

--- a/src/main/java/com/lielamar/auth/shared/utils/NumbersUtils.java
+++ b/src/main/java/com/lielamar/auth/shared/utils/NumbersUtils.java
@@ -1,0 +1,14 @@
+package com.lielamar.auth.shared.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+public class NumbersUtils {
+
+    public static boolean isInteger(@NotNull String number) {
+        try {
+            Integer.parseInt(number);
+            return true;
+        } catch(NumberFormatException ignored) {}
+        return false;
+    }
+}

--- a/src/main/java/com/lielamar/auth/shared/utils/color/ColorUtils.java
+++ b/src/main/java/com/lielamar/auth/shared/utils/color/ColorUtils.java
@@ -1,0 +1,38 @@
+package com.lielamar.auth.shared.utils.color;
+
+import net.md_5.bungee.api.ChatColor;
+
+public class ColorUtils {
+
+    /**
+     * Colors a Bukkit message with support to hex color codes
+     *
+     * @param codeChar   char to use to translate color codes
+     * @param message    Message to color
+     * @return           Colored message
+     */
+    public static String translateAlternateColorCodes(char codeChar, String message) {
+        char[] chars = message.toCharArray();
+
+        StringBuilder builder  = new StringBuilder();
+        String colorHex = "";
+
+        boolean isHex = false;
+
+        for(int i = 0; i < chars.length; i++) {
+            if(chars[i] == codeChar && i < chars.length - 1 && chars[i+1] == '#'){
+                colorHex = "";
+                isHex = true;
+            } else if(isHex) {
+                colorHex += chars[i];
+                isHex = colorHex.length() < 7;
+
+                if(!isHex)
+                    builder.append(ChatColor.of(colorHex));
+            } else
+                builder.append(chars[i]);
+        }
+
+        return ChatColor.translateAlternateColorCodes(codeChar, builder.toString());
+    }
+}

--- a/src/main/java/com/lielamar/auth/shared/utils/groups/Pair.java
+++ b/src/main/java/com/lielamar/auth/shared/utils/groups/Pair.java
@@ -1,0 +1,18 @@
+package com.lielamar.auth.shared.utils.groups;
+
+public class Pair<A, B> {
+
+    private A a;
+    private B b;
+
+    public Pair(A a, B b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public A getA() { return a; }
+    public void setA(A a) { this.a = a; }
+
+    public B getB() { return b; }
+    public void setB(B b) { this.b = b; }
+}

--- a/src/main/java/com/lielamar/auth/velocity/TwoFactorAuthentication.java
+++ b/src/main/java/com/lielamar/auth/velocity/TwoFactorAuthentication.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 
 import java.nio.file.Path;
 
-@Plugin(id = "twofa", name = "2FA", version = "1.6.4", description = "Add another layer of protection to your server", authors = {"Liel Amar", "SadGhost", "Wolfity"})
+@Plugin(id = "twofa", name = "2FA", version = "1.7", description = "Add another layer of protection to your server", authors = {"Liel Amar", "SadGhost", "Wolfity"})
 public class TwoFactorAuthentication implements TwoFactorAuthenticationPlugin {
 
     private final ProxyServer proxy;

--- a/src/main/java/com/lielamar/auth/velocity/TwoFactorAuthentication.java
+++ b/src/main/java/com/lielamar/auth/velocity/TwoFactorAuthentication.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 
 import java.nio.file.Path;
 
-@Plugin(id = "twofa", name = "2FA", version = "1.7", description = "Add another layer of protection to your server", authors = {"Liel Amar", "SadGhost", "Wolfity"})
+@Plugin(id = "twofa", name = "2FA", version = "1.7.0", description = "Add another layer of protection to your server", authors = {"Liel Amar", "SadGhost", "Wolfity"})
 public class TwoFactorAuthentication implements TwoFactorAuthenticationPlugin {
 
     private final ProxyServer proxy;

--- a/src/main/java/com/lielamar/auth/velocity/handlers/MessageHandler.java
+++ b/src/main/java/com/lielamar/auth/velocity/handlers/MessageHandler.java
@@ -1,11 +1,10 @@
 package com.lielamar.auth.velocity.handlers;
 
+import com.lielamar.auth.shared.utils.groups.Pair;
 import com.lielamar.auth.velocity.TwoFactorAuthentication;
-import com.lielamar.lielsutils.groups.Pair;
 import com.moandjiezana.toml.Toml;
 import com.velocitypowered.api.proxy.Player;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.audience.MessageType;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.jetbrains.annotations.NotNull;
@@ -34,20 +33,20 @@ public class MessageHandler extends com.lielamar.auth.shared.handlers.MessageHan
     protected void sendRaw(final Object player, final String message, TextColor color) {
         if (player instanceof Player) {
             Audience.audience((Player) player).sendMessage(
-                    Component.text().content(message).color(color).build(),
-                    MessageType.CHAT);
+                    Component.text().content(message).color(color).build()
+            );
         }
     }
 
     public void sendMessage(Object sender, TwoFAMessages message) {
-        this.sendMessage(sender, (TwoFAMessages.PREFIX.getMessage().length() > 0), message);
+        this.sendMessage(sender, (!TwoFAMessages.PREFIX.getMessage().isEmpty()), message);
     }
 
     protected void sendMessage(Object sender, boolean prefix, TwoFAMessages message, Pair<?, ?>... args) {
         String raw = message.getMessage();
         String rawPrefix = TwoFAMessages.PREFIX.getMessage();
 
-        if (raw != null && raw.length() > 0) {
+        if (raw != null && !raw.isEmpty()) {
             for (Pair<?, ?> pair : args) {
                 raw = raw.replaceAll(pair.getA().toString(), pair.getB().toString());
             }

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: 2FA
-version: "1.6.4"
+version: "1.7"
 author: "LielAmar"
 authors: ["LielAmar", "SadGhost", "Wolfity"]
 main: com.lielamar.auth.bungee.TwoFactorAuthentication

--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: 2FA
-version: "1.7"
+version: "1.7.0"
 author: "LielAmar"
 authors: ["LielAmar", "SadGhost", "Wolfity"]
 main: com.lielamar.auth.bungee.TwoFactorAuthentication

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,9 +9,6 @@
 # Github: https://github.com/LielAmar/2FA
 # ===========================================================================================
 
-# Service to use when generating QR codes
-qr-code-service: "https://www.google.com/chart?chs=128x128&cht=qr&chl=otpauth://totp/"
-
 # Whether to notify when there's an update available
 check-for-updates: true
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: 2FA
-version: "1.6.4"
+version: "1.7"
 api-version: 1.13
 authors: [LielAmar, SadGhost, Wolfity]
 main: com.lielamar.auth.bukkit.TwoFactorAuthentication
@@ -7,16 +7,16 @@ description: Add another layer of protection to your server
 softdepend: [PlaceholderAPI]
 
 libraries:
-  - com.warrenstrange:googleauth:1.5.0
-  - commons-codec:commons-codec:1.15
-  - com.zaxxer:HikariCP:4.0.3
-  - com.h2database:h2:2.1.212
-  - mysql:mysql-connector-java:8.0.29
-  - org.mariadb.jdbc:mariadb-java-client:3.0.5
-  - org.postgresql:postgresql:42.3.6
-  - org.mongodb:mongo-java-driver:3.12.11
-  - org.slf4j:slf4j-api:2.0.0-alpha7
-  - org.apache.logging.log4j:log4j-core:2.18.0
+  - commons-codec:commons-codec:1.17.0
+  - com.zaxxer:HikariCP:5.1.0
+  - com.h2database:h2:2.2.224
+  - mysql:mysql-connector-java:8.4.0
+  - org.mariadb.jdbc:mariadb-java-client:3.4.0
+  - org.postgresql:postgresql:42.7.3
+  - org.mongodb:mongodb-driver-sync:5.1.1
+  - org.slf4j:slf4j-api:2.0.13
+  - org.apache.logging.log4j:log4j-core:2.23.1
+  - com.atlassian:onetime:2.1.1
 
 commands:
   2fa:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: 2FA
-version: "1.7"
+version: "1.7.0"
 api-version: 1.13
 authors: [LielAmar, SadGhost, Wolfity]
 main: com.lielamar.auth.bukkit.TwoFactorAuthentication

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ description: Add another layer of protection to your server
 softdepend: [PlaceholderAPI]
 
 libraries:
+  - org.jetbrains.kotlin:kotlin-stdlib:2.0.0
   - commons-codec:commons-codec:1.17.0
   - com.zaxxer:HikariCP:5.1.0
   - com.h2database:h2:2.2.224

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "twofa",
   "name": "2FA",
-  "version": "1.6.3",
+  "version": "1.7",
   "description": "Add another layer of protection to your server",
   "authors": [
     "Liel Amar",

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "twofa",
   "name": "2FA",
-  "version": "1.7",
+  "version": "1.7.0",
   "description": "Add another layer of protection to your server",
   "authors": [
     "Liel Amar",


### PR DESCRIPTION
1.7 Update:
-

For this update, a lot has changed in the codebase.
The plugin will be compiled via Java 17, and should support all versions from 1.8 - 1.21.

The plugin will be generating QR codes now instead of using external services, and the 2FA system will support every auth app.

Changelog:
-
- Now Supporting 1.8 - 1.21 Minecraft Versions
- Plugin Uses Now Java 17
- Atlassian's OneTime Library for 2FA
- Plugin Generates QR codes by itself instead of external URLs.
- Authentication is now fixed.